### PR TITLE
A bunch of fixes

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -231,13 +231,13 @@ class Appliance:
         ]
 
     @property
-    def speed_range(self):
+    def speed_range(self) -> tuple:
         if self.model == "WELLA7":
             return 1, 5
         if self.model == "PUREA9":
             return 1, 9
 
-        return 0
+        return 0, 0
 
 
 class Appliances:

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -244,7 +244,7 @@ class Appliances:
     def __init__(self, appliances) -> None:
         self.appliances = appliances
 
-    def get_appliance(self, pnc_id):
+    def get_appliance(self, pnc_id) -> Appliance | None:
         return self.appliances.get(pnc_id, None)
 
 

--- a/custom_components/wellbeing/config_flow.py
+++ b/custom_components/wellbeing/config_flow.py
@@ -25,10 +25,6 @@ class WellbeingFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         self._errors = {}
 
-        # Uncomment the next 2 lines if only a single instance of the integration is allowed:
-        # if self._async_current_entries():
-        #     return self.async_abort(reason="single_instance_allowed")
-
         if user_input is not None:
             valid = await self._test_credentials(
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD]

--- a/custom_components/wellbeing/entity.py
+++ b/custom_components/wellbeing/entity.py
@@ -16,7 +16,7 @@ class WellbeingEntity(CoordinatorEntity):
         self.entity_type = entity_type
         self.config_entry = config_entry
         self.pnc_id = pnc_id
-        self.entity_id = ENTITY_ID_FORMAT.format(f"{DEFAULT_NAME}_{self.entity_attr}")
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{DEFAULT_NAME}_{self.get_appliance.name}_{self.entity_attr}")
 
     @property
     def name(self):

--- a/custom_components/wellbeing/fan.py
+++ b/custom_components/wellbeing/fan.py
@@ -50,11 +50,6 @@ class WellbeingFan(WellbeingEntity, FanEntity):
         return self.get_appliance.speed_range
 
     @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self.get_entity.name
-
-    @property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return self._speed_range[1]

--- a/custom_components/wellbeing/fan.py
+++ b/custom_components/wellbeing/fan.py
@@ -46,7 +46,7 @@ class WellbeingFan(WellbeingEntity, FanEntity):
         self._speed = self.get_entity.state
 
     @property
-    def _speed_range(self):
+    def _speed_range(self) -> tuple:
         return self.get_appliance.speed_range
 
     @property
@@ -57,7 +57,7 @@ class WellbeingFan(WellbeingEntity, FanEntity):
     @property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
-        return len(self.speed_list)
+        return self._speed_range[1]
 
     @property
     def percentage(self):

--- a/custom_components/wellbeing/translations/en.json
+++ b/custom_components/wellbeing/translations/en.json
@@ -2,7 +2,6 @@
   "config": {
     "step": {
       "user": {
-        "title": "Wellbeing",
         "description": "If you need help with the configuration have a look here: https://github.com/JohNan/homeassistant-wellbeing",
         "data": {
           "username": "Username",

--- a/custom_components/wellbeing/translations/fr.json
+++ b/custom_components/wellbeing/translations/fr.json
@@ -2,7 +2,6 @@
   "config": {
     "step": {
       "user": {
-        "title": "Wellbeing",
         "description": "Si vous avez besoin d'aide pour la configuration, regardez ici: https://github.com/JohNan/homeassistant-wellbeing",
         "data": {
           "username": "Identifiant",

--- a/custom_components/wellbeing/translations/nb.json
+++ b/custom_components/wellbeing/translations/nb.json
@@ -2,7 +2,6 @@
   "config": {
     "step": {
       "user": {
-        "title": "Wellbeing",
         "description": "Hvis du trenger hjep til konfigurasjon ta en titt her: https://github.com/JohNan/homeassistant-wellbeing",
         "data": {
           "username": "Brukernavn",

--- a/custom_components/wellbeing/translations/pl.json
+++ b/custom_components/wellbeing/translations/pl.json
@@ -2,7 +2,6 @@
   "config": {
     "step": {
       "user": {
-        "title": "Wellbeing",
         "description": "Jeśli potrzebujesz pomocy z konfiguracją zajrzyj tutaj: https://github.com/JohNan/homeassistant-wellbeing",
         "data": {
           "username": "Nazwa użytkownika",


### PR DESCRIPTION
Should fix https://github.com/JohNan/homeassistant-wellbeing/issues/26 and https://github.com/JohNan/homeassistant-wellbeing/issues/25

It will not migrate any old entity ids but when setting up a new integration the name of the appliance will be included in the entity id