### PR TITLE
Remove user agent from API requests

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -297,7 +297,6 @@ class WellbeingApiClient:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            # "User-Agent": USER_AGENT
         }
         return await self.api_wrapper("post", TOKEN_URL, json, headers)
 

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -309,7 +309,6 @@ class WellbeingApiClient:
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
-            # "User-Agent": USER_AGENT,
             "x-api-key": X_API_KEY
         }
         return await self.api_wrapper("post", AUTHENTICATION_URL, credentials, headers)

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -297,7 +297,7 @@ class WellbeingApiClient:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": USER_AGENT
+            # "User-Agent": USER_AGENT
         }
         return await self.api_wrapper("post", TOKEN_URL, json, headers)
 
@@ -310,7 +310,7 @@ class WellbeingApiClient:
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": USER_AGENT,
+            # "User-Agent": USER_AGENT,
             "x-api-key": X_API_KEY
         }
         return await self.api_wrapper("post", AUTHENTICATION_URL, credentials, headers)
@@ -324,7 +324,7 @@ class WellbeingApiClient:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": USER_AGENT,
+            # "User-Agent": USER_AGENT,
             "Origin-Country-Code": country_code
         }
         return await self.api_wrapper("post", TOKEN_URL, credentials, headers)
@@ -334,7 +334,7 @@ class WellbeingApiClient:
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": USER_AGENT,
+            # "User-Agent": USER_AGENT,
             "x-api-key": X_API_KEY
         }
         return await self.api_wrapper("get", APPLIANCES_URL, headers=headers)
@@ -344,7 +344,7 @@ class WellbeingApiClient:
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": USER_AGENT,
+            # "User-Agent": USER_AGENT,
             "x-api-key": X_API_KEY
         }
         url = f"{APPLIANCES_URL}/{pnc_id}/info"
@@ -453,7 +453,7 @@ class WellbeingApiClient:
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": USER_AGENT,
+            # "User-Agent": USER_AGENT,
             "x-api-key": X_API_KEY
         }
 

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -340,7 +340,6 @@ class WellbeingApiClient:
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
-            # "User-Agent": USER_AGENT,
             "x-api-key": X_API_KEY
         }
         url = f"{APPLIANCES_URL}/{pnc_id}/info"

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -448,7 +448,6 @@ class WellbeingApiClient:
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
-            # "User-Agent": USER_AGENT,
             "x-api-key": X_API_KEY
         }
 

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -331,7 +331,6 @@ class WellbeingApiClient:
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
-            # "User-Agent": USER_AGENT,
             "x-api-key": X_API_KEY
         }
         return await self.api_wrapper("get", APPLIANCES_URL, headers=headers)

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -322,7 +322,6 @@ class WellbeingApiClient:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            # "User-Agent": USER_AGENT,
             "Origin-Country-Code": country_code
         }
         return await self.api_wrapper("post", TOKEN_URL, credentials, headers)

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -296,7 +296,7 @@ class WellbeingApiClient:
         }
         headers = {
             "Content-Type": "application/json",
-            "Accept": "application/json",
+            "Accept": "application/json"
         }
         return await self.api_wrapper("post", TOKEN_URL, json, headers)
 


### PR DESCRIPTION
Seems like the Electrolux API does no longer like the `User-Agent: Electrolux/2.9 android/9` header. Requests which include this header might receive a HTTP status 429 "Too many requests" response.
This PR removes this header from all API requests. This should address #96 