### PR TITLE
Fix fan toggle error.

### DIFF
--- a/custom_components/wellbeing/fan.py
+++ b/custom_components/wellbeing/fan.py
@@ -39,9 +39,6 @@ async def async_setup_entry(hass, entry, async_add_devices):
 class WellbeingFan(WellbeingEntity, FanEntity):
     """wellbeing Sensor class."""
 
-    # Add FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON and set to True before 2025.2
-    _enable_turn_on_off_backwards_compatibility = False
-
     def __init__(self, coordinator: WellbeingDataUpdateCoordinator, config_entry, pnc_id, entity_type, entity_attr):
         super().__init__(coordinator, config_entry, pnc_id, entity_type, entity_attr)
         self._preset_mode = self.get_appliance.mode


### PR DESCRIPTION
The integration will still warn about missing feature flags, but we can live with the warning until people have updated HA to at least 2024.08