### PR TITLE
Support for the PUREi9 Robot Vacuum

### DIFF
--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -23,7 +23,13 @@ from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, CONF_REFRESH_TOKEN
 from .const import DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
-PLATFORMS = [Platform.SENSOR, Platform.FAN, Platform.BINARY_SENSOR, Platform.SWITCH]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.FAN,
+    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+    Platform.VACUUM,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -38,13 +44,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     token_manager = WellBeingTokenManager(hass, entry)
     try:
-        hub = ElectroluxHubAPI(session=async_get_clientsession(hass), token_manager=token_manager)
+        hub = ElectroluxHubAPI(
+            session=async_get_clientsession(hass), token_manager=token_manager
+        )
     except Exception as exception:
         raise ConfigEntryAuthFailed("Failed to setup API") from exception
 
     client = WellbeingApiClient(hub)
 
-    coordinator = WellbeingDataUpdateCoordinator(hass, client=client, update_interval=update_interval)
+    coordinator = WellbeingDataUpdateCoordinator(
+        hass, client=client, update_interval=update_interval
+    )
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -76,7 +86,12 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 class WellbeingDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
-    def __init__(self, hass: HomeAssistant, client: WellbeingApiClient, update_interval: timedelta) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: WellbeingApiClient,
+        update_interval: timedelta,
+    ) -> None:
         """Initialize."""
         self.api = client
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
@@ -108,7 +123,11 @@ class WellBeingTokenManager(TokenManager):
 
         self._hass.config_entries.async_update_entry(
             self._entry,
-            data={CONF_API_KEY: self.api_key, CONF_REFRESH_TOKEN: refresh_token, CONF_ACCESS_TOKEN: access_token},
+            data={
+                CONF_API_KEY: self.api_key,
+                CONF_REFRESH_TOKEN: refresh_token,
+                CONF_ACCESS_TOKEN: access_token,
+            },
         )
 
     @staticmethod

--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -44,17 +44,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     token_manager = WellBeingTokenManager(hass, entry)
     try:
-        hub = ElectroluxHubAPI(
-            session=async_get_clientsession(hass), token_manager=token_manager
-        )
+        hub = ElectroluxHubAPI(session=async_get_clientsession(hass), token_manager=token_manager)
     except Exception as exception:
         raise ConfigEntryAuthFailed("Failed to setup API") from exception
 
     client = WellbeingApiClient(hub)
 
-    coordinator = WellbeingDataUpdateCoordinator(
-        hass, client=client, update_interval=update_interval
-    )
+    coordinator = WellbeingDataUpdateCoordinator(hass, client=client, update_interval=update_interval)
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -86,12 +82,7 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 class WellbeingDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        client: WellbeingApiClient,
-        update_interval: timedelta,
-    ) -> None:
+    def __init__(self, hass: HomeAssistant, client: WellbeingApiClient, update_interval: timedelta) -> None:
         """Initialize."""
         self.api = client
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
@@ -122,12 +113,7 @@ class WellBeingTokenManager(TokenManager):
         _LOGGER.debug(f"Refresh token: {self._mask_access_token(refresh_token)}")
 
         self._hass.config_entries.async_update_entry(
-            self._entry,
-            data={
-                CONF_API_KEY: self.api_key,
-                CONF_REFRESH_TOKEN: refresh_token,
-                CONF_ACCESS_TOKEN: access_token,
-            },
+            data={CONF_API_KEY: self.api_key, CONF_REFRESH_TOKEN: refresh_token, CONF_ACCESS_TOKEN: access_token},
         )
 
     @staticmethod

--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -113,6 +113,7 @@ class WellBeingTokenManager(TokenManager):
         _LOGGER.debug(f"Refresh token: {self._mask_access_token(refresh_token)}")
 
         self._hass.config_entries.async_update_entry(
+            self._entry,
             data={CONF_API_KEY: self.api_key, CONF_REFRESH_TOKEN: refresh_token, CONF_ACCESS_TOKEN: access_token},
         )
 

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -121,9 +121,7 @@ class ApplianceVacuum(ApplianceEntity):
 class ApplianceBinary(ApplianceEntity):
     entity_type: int = Platform.BINARY_SENSOR
 
-    def __init__(
-        self, name, attr, device_class=None, entity_category: EntityCategory = UNDEFINED
-    ) -> None:
+    def __init__(self, name, attr, device_class=None, entity_category: EntityCategory = UNDEFINED) -> None:
         super().__init__(name, attr, device_class, entity_category)
 
     @property
@@ -203,19 +201,12 @@ class Appliance:
         ]
 
         purei9_entities = [
-            # ApplianceSensor(  # Test Robot Vacuum Battery Sensor
-            #    name="Battery Status",
-            #    attr="batteryStatus",
-            #    device_class=SensorDeviceClass.BATTERY,
-            #    state_class=SensorStateClass.MEASUREMENT,
-            # ),
-            ApplianceSensor(  # Test Robot Vacuum Robot Sensor
+            ApplianceSensor( 
                 name="Dustbin Status",
                 attr="dustbinStatus",
                 device_class=SensorDeviceClass.ENUM,
-                state_class=SensorStateClass.MEASUREMENT,
             ),
-            ApplianceVacuum(  # Test Robot Vacuum
+            ApplianceVacuum(
                 name="Vacuum",
                 attr="robotStatus",
             ),
@@ -234,10 +225,7 @@ class Appliance:
                 state_class=SensorStateClass.MEASUREMENT,
             ),
             ApplianceSensor(
-                name="TVOC",
-                attr="TVOC",
-                unit=CONCENTRATION_PARTS_PER_BILLION,
-                state_class=SensorStateClass.MEASUREMENT,
+                name="TVOC", attr="TVOC", unit=CONCENTRATION_PARTS_PER_BILLION, state_class=SensorStateClass.MEASUREMENT
             ),
             ApplianceSensor(
                 name="eCO2",
@@ -274,9 +262,7 @@ class Appliance:
                 device_class=SensorDeviceClass.HUMIDITY,
                 state_class=SensorStateClass.MEASUREMENT,
             ),
-            ApplianceSensor(
-                name="Mode", attr="Workmode", device_class=SensorDeviceClass.ENUM
-            ),
+            ApplianceSensor(name="Mode", attr="Workmode", device_class=SensorDeviceClass.ENUM),
             ApplianceSensor(
                 name="Signal Strength",
                 attr="SignalStrength",
@@ -297,14 +283,8 @@ class Appliance:
                 device_class=BinarySensorDeviceClass.CONNECTIVITY,
                 entity_category=EntityCategory.DIAGNOSTIC,
             ),
-            ApplianceBinary(
-                name="Status", attr="status", entity_category=EntityCategory.DIAGNOSTIC
-            ),
-            ApplianceBinary(
-                name="Safety Lock",
-                attr="SafetyLock",
-                device_class=BinarySensorDeviceClass.LOCK,
-            ),
+            ApplianceBinary(name="Status", attr="status", entity_category=EntityCategory.DIAGNOSTIC),
+            ApplianceBinary(name="Safety Lock", attr="SafetyLock", device_class=BinarySensorDeviceClass.LOCK),
         ]
 
         return (
@@ -317,16 +297,11 @@ class Appliance:
 
     def get_entity(self, entity_type, entity_attr):
         return next(
-            entity
-            for entity in self.entities
-            if entity.attr == entity_attr and entity.entity_type == entity_type
+            entity for entity in self.entities if entity.attr == entity_attr and entity.entity_type == entity_type
         )
 
     def has_capability(self, capability) -> bool:
-        return (
-            capability in self.capabilities
-            and self.capabilities[capability]["access"] == "readwrite"
-        )
+        return capability in self.capabilities and self.capabilities[capability]["access"] == "readwrite"
 
     def clear_mode(self):
         self.mode = WorkMode.UNDEFINED
@@ -344,11 +319,7 @@ class Appliance:
             self.battery_status = data.get("batteryStatus")
 
         self.capabilities = capabilities
-        self.entities = [
-            entity.setup(data)
-            for entity in Appliance._create_entities(data)
-            if entity.attr in data
-        ]
+        self.entities = [entity.setup(data) for entity in Appliance._create_entities(data) if entity.attr in data]
 
     @property
     def preset_modes(self) -> list[WorkMode]:
@@ -397,6 +368,7 @@ class Appliances:
 
 
 class WellbeingApiClient:
+
     def __init__(self, hub: ElectroluxHubAPI) -> None:
         """Sample API Client."""
         self._api_appliances: dict[str, ApiAppliance] = {}
@@ -432,9 +404,7 @@ class WellbeingApiClient:
 
             data = appliance.state
             data["status"] = appliance.state_data.get("status", "unknown")
-            data["connectionState"] = appliance.state_data.get(
-                "connectionState", "unknown"
-            )
+            data["connectionState"] = appliance.state_data.get("connectionState", "unknown")
 
             app.setup(data, appliance.capabilities_data)
 
@@ -459,9 +429,7 @@ class WellbeingApiClient:
         }  # Not the right formatting. Disable FAN_SPEEDS until this is figured out
         appliance = self._api_appliances.get(pnc_id, None)
         if appliance is None:
-            _LOGGER.error(
-                f"Failed to set vacuum power mode for appliance with id {pnc_id}"
-            )
+            _LOGGER.error(f"Failed to set feature {feature} for appliance with id {pnc_id}")
             return
         result = await appliance.send_command(data)
         _LOGGER.debug(f"Set Vacuum Power Mode: {result}")

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -460,9 +460,7 @@ class WellbeingApiClient:
         data = {feature: state}
         appliance = self._api_appliances.get(pnc_id, None)
         if appliance is None:
-            _LOGGER.error(
-                f"Failed to set feature {feature} for appliance with id {pnc_id}"
-            )
+            _LOGGER.error(f"Failed to set feature {feature} for appliance with id {pnc_id}")
             return
 
         await appliance.send_command(data)

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -358,6 +358,23 @@ class Appliance:
 
         return 0, 0
 
+    @property
+    def battery_range(self) -> tuple[int, int]:
+        if self.model == Model.PUREi9:
+            return 2, 6 # Do not include lowest value of 1 to make this mean empty (0%) battery
+
+        return 0, 0
+
+    @property
+    def vacuum_fan_speeds(self) -> dict[int, str]:
+        if self.model == Model.PUREi9:
+            return {
+                1: "Quiet",
+                2: "Smart",
+                3: "Power",
+            }
+        return {}
+
 
 class Appliances:
     def __init__(self, appliances) -> None:

--- a/custom_components/wellbeing/vacuum.py
+++ b/custom_components/wellbeing/vacuum.py
@@ -10,6 +10,8 @@ from homeassistant.components.vacuum import (
     STATE_PAUSED,
     STATE_RETURNING,
     STATE_IDLE,
+    STATE_DOCKED,
+    STATE_ERROR,
 )
 from homeassistant.const import Platform
 from homeassistant.util.percentage import (
@@ -96,8 +98,6 @@ class WellbeingVacuum(WellbeingEntity, StateVacuumEntity):
         entity_attr,
     ):
         super().__init__(coordinator, config_entry, pnc_id, entity_type, entity_attr)
-        self._power_mode = self.get_appliance.power_mode
-        self._battery_status = self.get_appliance.battery_status
 
     @property
     def supported_features(self) -> int:
@@ -106,24 +106,22 @@ class WellbeingVacuum(WellbeingEntity, StateVacuumEntity):
     @property
     def state(self):
         """Return the state of the vacuum."""
-        if self.get_entity.state in VACUUM_STATES:
-            return VACUUM_STATES[self.get_entity.state]
-        return self.get_entity.state
+        return VACUUM_STATES.get(self.get_entity.state, STATE_ERROR)
 
     @property
     def battery_level(self):
         """Return the battery level of the vacuum based on the status from 0-6."""
-        return BATTERY_LEVELS.get(self._battery_status, 0)
+        return BATTERY_LEVELS.get(self.get_appliance.battery_status, 0)
 
     @property
     def battery_icon(self):
         """Return the battery icon of the vacuum based on the status from 0-6."""
-        return BATTERY_ICONS.get(self._battery_status, "mdi:battery-unknown")
+        return BATTERY_ICONS.get(self.get_appliance.battery_status, "mdi:battery-unknown")
 
     @property
     def fan_speed(self):
         """Return the fan speed of the vacuum cleaner."""
-        return FAN_SPEEDS.get(self._power_mode, "Unknown")
+        return FAN_SPEEDS.get(self.get_appliance.power_mode, "Unknown")
 
     @property
     def fan_speed_list(self):

--- a/custom_components/wellbeing/vacuum.py
+++ b/custom_components/wellbeing/vacuum.py
@@ -1,0 +1,150 @@
+"""Vacuum platform for Wellbeing."""
+
+import asyncio
+import logging
+import math
+
+from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
+from homeassistant.components.vacuum import (
+    STATE_CLEANING,
+    STATE_PAUSED,
+    STATE_RETURNING,
+    STATE_IDLE,
+)
+from homeassistant.const import Platform
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+
+from . import WellbeingDataUpdateCoordinator
+from .const import DOMAIN
+from .entity import WellbeingEntity
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+SUPPORTED_FEATURES = (
+    VacuumEntityFeature.START
+    | VacuumEntityFeature.STOP
+    | VacuumEntityFeature.PAUSE
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.BATTERY
+)
+
+VACUUM_STATES = {
+    1: STATE_CLEANING,
+    2: STATE_PAUSED,
+    5: STATE_RETURNING,
+    10: STATE_IDLE,
+}
+
+BATTERY_LEVELS = {
+    0: 0,
+    1: 10,
+    2: 30,
+    3: 50,
+    4: 70,
+    5: 90,
+    6: 100,
+}
+
+BATTERY_ICONS = {
+    0: "mdi:battery-alert-variant-outline",
+    1: "mdi:battery-10",
+    2: "mdi:battery-30",
+    3: "mdi:battery-50",
+    4: "mdi:battery-70",
+    5: "mdi:battery-90",
+    6: "mdi:battery",
+}
+
+
+FAN_SPEEDS = {
+    1: "Quiet",
+    2: "Smart",
+    3: "Power",
+}
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Setup vacuum platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    appliances = coordinator.data.get("appliances", None)
+
+    if appliances is not None:
+        for pnc_id, appliance in appliances.appliances.items():
+            async_add_devices(
+                [
+                    WellbeingVacuum(
+                        coordinator, entry, pnc_id, entity.entity_type, entity.attr
+                    )
+                    for entity in appliance.entities
+                    if entity.entity_type == Platform.VACUUM
+                ]
+            )
+
+
+class WellbeingVacuum(WellbeingEntity, StateVacuumEntity):
+    """wellbeing Sensor class."""
+
+    def __init__(
+        self,
+        coordinator: WellbeingDataUpdateCoordinator,
+        config_entry,
+        pnc_id,
+        entity_type,
+        entity_attr,
+    ):
+        super().__init__(coordinator, config_entry, pnc_id, entity_type, entity_attr)
+        self._power_mode = self.get_appliance.power_mode
+        self._battery_status = self.get_appliance.battery_status
+
+    @property
+    def supported_features(self) -> int:
+        return SUPPORTED_FEATURES
+
+    @property
+    def state(self):
+        """Return the state of the vacuum."""
+        if self.get_entity.state in VACUUM_STATES:
+            return VACUUM_STATES[self.get_entity.state]
+        return self.get_entity.state
+
+    @property
+    def battery_level(self):
+        """Return the battery level of the vacuum based on the status from 0-6."""
+        return BATTERY_LEVELS.get(self._battery_status, 0)
+
+    @property
+    def battery_icon(self):
+        """Return the battery icon of the vacuum based on the status from 0-6."""
+        return BATTERY_ICONS.get(self._battery_status, "mdi:battery-unknown")
+
+    @property
+    def fan_speed(self):
+        """Return the fan speed of the vacuum cleaner."""
+        return FAN_SPEEDS.get(self._power_mode, "Unknown")
+
+    @property
+    def fan_speed_list(self):
+        """Get the list of available fan speed steps of the vacuum cleaner."""
+        return list(FAN_SPEEDS.values())
+
+    async def async_start(self):
+        await self.api.command_vacuum(self.pnc_id, "play")
+
+    async def async_stop(self):
+        await self.api.command_vacuum(self.pnc_id, "stop")
+
+    async def async_pause(self):
+        await self.api.command_vacuum(self.pnc_id, "pause")
+
+    async def async_return_to_base(self):
+        await self.api.command_vacuum(self.pnc_id, "home")
+
+    async def async_set_fan_speed(self, fan_speed: str):
+        """Set the fan speed of the vacuum cleaner."""
+        for mode, name in FAN_SPEEDS.items():
+            if name == fan_speed:
+                await self.api.set_vacuum_power_mode(self.pnc_id, mode)
+                break

--- a/custom_components/wellbeing/vacuum.py
+++ b/custom_components/wellbeing/vacuum.py
@@ -34,10 +34,20 @@ SUPPORTED_FEATURES = (
 )
 
 VACUUM_STATES = {
-    1: STATE_CLEANING,
+    1: STATE_CLEANING,  # Regular Cleaning
     2: STATE_PAUSED,
+    3: STATE_CLEANING,  # Stop cleaning
+    4: STATE_PAUSED,  # Pause Spot cleaning
     5: STATE_RETURNING,
+    6: STATE_PAUSED,  # Paused returning
+    7: STATE_RETURNING,  # Returning for pitstop
+    8: STATE_PAUSED,  # Paused returning for pitstop
+    9: STATE_DOCKED,  # Charging
     10: STATE_IDLE,
+    11: STATE_ERROR,
+    12: STATE_DOCKED,  # Pitstop
+    13: STATE_IDLE,  # Manual stearing
+    14: STATE_IDLE,  # Firmware upgrading
 }
 
 BATTERY_LEVELS = {


### PR DESCRIPTION
In case you wish to not only support the line of air purifiers, I added basic support for the PUREi9.2 robot vacuum. I've been testing the code in a HA developer environment, and about a day in my production setup. It supports start, stop, pause, and return_to_base, along with battery status. The added functionality was (at least for me) mostly to get around the fac that "Home Assistant Pure i9", which builds on the purei9_unofficial python API, has been broken since August when Electrolux made changes to their API authorization. 

I was not completely sure of how to best pass on the battery state to the vacuum entity (rather than as a separate sensor) so I passed it with the application object I believe similar to how the the WorkMode of the air purifier fans is implemented, but it requires a bunch of special cases as the data object for the robot vacuum is a bit different that that of the air purifiers (e.g., no Workmode key). The vaccum.py class may also be a bit to hard coded. It was a bit hard to decide where to draw the line between the platform and functionality provided by api.py.

Next in line for implementation in my system is the fan mode (powerMode) setting (a skeleton if there but disabled because I was unsure of the formatting of the payload to send to the Wellbeing API), as well as support for sending the vacuum to a specific location.