### PR TITLE
Set default friendly_name of Vacuum entity to appliance name

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -207,7 +207,7 @@ class Appliance:
                 device_class=SensorDeviceClass.ENUM,
             ),
             ApplianceVacuum(
-                name="Vacuum",
+                name=data.get("applianceName","Vacuum"),
                 attr="robotStatus",
             ),
         ]


### PR DESCRIPTION
Minor change suggested by @blavak68 in https://github.com/JohNan/homeassistant-wellbeing/pull/145#issuecomment-2378392620 where the default friendly_name property of vacuum entities is derived from the appliance name instead of just being set to "Vacuum".