### PR TITLE
Added separate sensor to pass along raw robotStatus property to HA

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -201,14 +201,19 @@ class Appliance:
         ]
 
         purei9_entities = [
+            ApplianceVacuum(
+                name=data.get("applianceName","Vacuum"),
+                attr="robotStatus",
+            ),
             ApplianceSensor( 
                 name="Dustbin Status",
                 attr="dustbinStatus",
                 device_class=SensorDeviceClass.ENUM,
             ),
-            ApplianceVacuum(
-                name=data.get("applianceName","Vacuum"),
+            ApplianceSensor(
+                name="Robot Status",
                 attr="robotStatus",
+                device_class=SensorDeviceClass.ENUM,
             ),
         ]
 


### PR DESCRIPTION
I added a separate sensor for the raw robotState of the robot vacuums.

It is based on feedback [here](https://github.com/JohNan/homeassistant-wellbeing/pull/145#issuecomment-2376092987) and [here](https://github.com/JohNan/homeassistant-wellbeing/pull/145#issuecomment-2383211293). The issue is that the robotState is more expressive (e.g., returning or charging as part of a pitstop, to continue cleaning) than the states defined for the Vacuum Entity class in HA. By also exposing the robotState as a separate sensor for the device, one allows for more advanced automation possibilities.

I thought the added sensor was a cleaner option than expanding the Vacuum entity states with non-standard states for that entity class. I also opted to pass the numeric state along without trying to translate it to a string to keep implementation more straightforward and also (hopefully) allow, e.g., the new "Hygienic 700" robot vacuum to use the same code when eventually someone tries to use the get this into HA using the integration.
