### PR TITLE
Support for 700 series Robot Vacuum

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ A custom component designed for [Home Assistant](https://www.home-assistant.io) 
     - EHAW4010AG
     - EHAW6020AG
 
+- Electrolux PUREi9 Vacuum Robot
+    - PUREi9
+    - PUREi9.2
+
+- Electrolux PUREi9 Vacuum Robot
+    - PUREi9
+    - PUREi9.2
+
+- Electrolux 600/700 Series Vacuum Robot
+    - Clean 600
+    - Hygienic 600
+    - Hygienic 700
+    - Ultimate 700
+
 - AEG AX5 Air Purifiers
     - AX51-304WT
 
@@ -40,6 +54,15 @@ A custom component designed for [Home Assistant](https://www.home-assistant.io) 
     - AX91-405DG
     - AX91-604GY
     - AX91-604DG
+
+- AEG RX9 Vacuum Robot
+    - RX9
+    - RX9.2
+
+- AEG 6000/7000 Series Vacuum Robot
+    - 6000 Robot Vacuum Cleaner
+    - 7000 Robot Vacuum Cleaner
+
 
 ### Install with HACS (recommended)
 

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -236,6 +236,7 @@ class Appliance:
             ApplianceSensor(
                 name="Battery Status",
                 attr="batteryStatus",
+                unit=PERCENTAGE,
                 device_class=SensorDeviceClass.BATTERY,
             ),
             ApplianceSensor(

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -320,7 +320,6 @@ class Appliance:
             ApplianceBinary(name="Status", attr="status", entity_category=EntityCategory.DIAGNOSTIC),
             ApplianceBinary(name="Safety Lock", attr="SafetyLock", device_class=BinarySensorDeviceClass.LOCK),
         ]
-        _LOGGER.warning(f"_create_entities END")
 
         return (
             common_entities

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -486,7 +486,7 @@ class WellbeingApiClient:
     async def set_vacuum_power_mode(self, pnc_id: str, mode: int):
         data = {
             "powerMode": mode
-        }  # Not the right formatting. Disable FAN_SPEEDS until this is figured out        data = {}
+        }  # Not the right formatting. Disable FAN_SPEEDS until this is figured out
 
         appliance = self._api_appliances.get(pnc_id, None)
         if appliance is None:


### PR DESCRIPTION
I have added basic support for the 700 Series Robot Vacuum, the successor to the PUREi9 Series, which differs from the PUREi9 in terms of capabilities.

In this version, support for the 700 Series Vacuum Mode (also known as Power Mode in PUREi9) is not yet included, as I am still determining the best approach to implement this feature.

However, this basic implementation should allow users to set up essential automations.

This implementation provides basic vacuum support for the following models:

**Electrolux**
- Clean 600
- Hygienic 600
- Hygienic 700
- Ultimate 700

**AEG**
- 6000 Robot Vacuum Cleaner
- 7000 Robot Vacuum Cleaner