### PR TITLE
Fix vacuum battery reporting for PUREi9 and 700series

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -392,7 +392,7 @@ class Appliance:
     def battery_range(self) -> tuple[int, int]:
         match Model(self.model):
             case Model.Robot700series.value:
-                return 0, 100
+                return 1, 100
             case Model.PUREi9.value:
                 return 2, 6 # Do not include lowest value of 1 to make this mean empty (0%) battery
         return 0, 0

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -234,12 +234,6 @@ class Appliance:
                 device_class=SensorDeviceClass.ENUM,
             ),
             ApplianceSensor(
-                name="Battery Status",
-                attr="batteryStatus",
-                unit=PERCENTAGE,
-                device_class=SensorDeviceClass.BATTERY,
-            ),
-            ApplianceSensor(
                 name="Charging Status",
                 attr="chargingStatus",
                 device_class=SensorDeviceClass.ENUM,
@@ -396,9 +390,11 @@ class Appliance:
 
     @property
     def battery_range(self) -> tuple[int, int]:
-        if self.model == Model.PUREi9:
-            return 2, 6 # Do not include lowest value of 1 to make this mean empty (0%) battery
-
+        match Model(self.model):
+            case Model.Robot700series.value:
+                return 0, 100
+            case Model.PUREi9.value:
+                return 2, 6 # Do not include lowest value of 1 to make this mean empty (0%) battery
         return 0, 0
 
     @property

--- a/custom_components/wellbeing/vacuum.py
+++ b/custom_components/wellbeing/vacuum.py
@@ -53,7 +53,7 @@ VACUUM_STATES = {
     "sleeping": STATE_DOCKED,      # robot700series sleeping
 }
 
-VACUUM_CHARGING_STATE = 9 # For selecting battery icon
+VACUUM_CHARGING_STATES = [9, 'idle']
 
 
 async def async_setup_entry(hass, entry, async_add_devices):
@@ -111,8 +111,11 @@ class WellbeingVacuum(WellbeingEntity, StateVacuumEntity):
     def battery_icon(self):
         """Return the battery icon of the vacuum based on the battery level."""
         level = self.battery_level
-        charging = self.get_entity.state == VACUUM_CHARGING_STATE
+
+        charging = self.get_entity.state in VACUUM_CHARGING_STATES
+
         level = 10*round(level / 10) # Round level to nearest 10 for icon selection
+
         # Special cases given available icons
         if level == 100 and charging:
             return "mdi:battery-charging-100"
@@ -145,7 +148,6 @@ class WellbeingVacuum(WellbeingEntity, StateVacuumEntity):
                 command="play"
             case Model.Robot700series.value:
                 command="startGlobalClean"
-        _LOGGER.warning(f"VACUUM async_start {self.entity_type} {self.entity_attr} {command}")
         await self.api.command_vacuum(self.pnc_id, command)
 
     async def async_stop(self):


### PR DESCRIPTION
This change addresses the issues reported on PR #152 regarding incorrect battery value reporting for the PUREi9.

I removed the batteryStatus Sensor as it is already part of the ApplianceVacuum entity.

![Screenshot 2024-10-28 at 18 10 21](https://github.com/user-attachments/assets/b9e543bf-20e9-4d25-a179-adbb54198a15)
