### PR TITLE
Fix: Add model mapping for dehumidifier device type 'DH'

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -533,6 +533,9 @@ class WellbeingApiClient:
         """Sample API Client."""
         self._api_appliances: dict[str, ApiAppliance] = {}
         self._hub = hub
+        self._model_mapping = {
+            "DH": "UltimateHome 700",  # Map dehumidifier type to proper model name
+        }
 
     async def async_get_appliances(self) -> Appliances:
         """Get data from the API."""
@@ -544,7 +547,7 @@ class WellbeingApiClient:
         for appliance in (appliance for appliance in appliances):
             await appliance.async_update()
 
-            model_name = appliance.type
+            model_name = self._model_mapping.get(appliance.type, appliance.type)
             appliance_id = appliance.id
             appliance_name = appliance.name
 


### PR DESCRIPTION
## Description
Fixes #159 (based on your hard work of #168 ). This PR adds a model mapping to properly handle dehumidifier devices that report type 'DH', which previously failed with "DH is not a valid model" error.

### Changes
- Added a `_model_mapping` dictionary in `WellbeingApiClient` to translate device types to model names
- Added mapping from 'DH' to 'UltimateHome 700' for dehumidifiers
- Updated model name assignment to use this mapping with fallback to original type

### Testing
Successfully tested on a real Electrolux dehumidifier device:
- Device now initializes correctly as UltimateHome 700 model
- All dehumidifier entities and capabilities work as expected
- Verified no impact on other appliance types