### PR TITLE
Fixes bug where appliance firmware is not set

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -442,6 +442,7 @@ class Appliance:
         self.mode = mode
 
     def setup(self, data, capabilities):
+        self.firmware = ""
         if "FrmVer_NIU" in data:
             self.firmware = data.get("FrmVer_NIU")
         if "VmNo_NIU" in data:
@@ -450,8 +451,6 @@ class Appliance:
             self.firmware = data.get("applianceUiSwVersion")
         if "firmwareVersion" in data:
             self.firmware = data.get("firmwareVersion")
-        if not hasattr(self, "firmware"):
-            self.firmware = ""
         if "Workmode" in data:
             self.mode = WorkMode(data.get("Workmode"))
         if "LouverSwingWorkmode" in data:


### PR DESCRIPTION
There was a bug in the recently added code to retrieve the appliance firmwares, starting with line 445 in api.py. If the firmware field of the JSON data object returned by the Electrolux API does not conform to one of the listed formats, the firmware attribute was never set. This, in turn, will cause the code to throw an exception when the firmware attribute is accessed on line 48 in entity.py. This PR adds a fallback for when no known firmware is found (by setting the firmware field to an empty string) to prevent the error from being thrown in entity.py and correctly retrieves the firmware field for the Purei9 RVC.

The code has been tested in HA, both the fallback, which causes the firmware to be listed at 0.0, and for the Purei9 RVC, where it is listed correctly.