### PR TITLE
Zone cleaning functionality implemented for the PUREi9

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,12 +1,12 @@
 # Electrolux Wellbeing - Manual
 
-This text contains manual entries for non-obvious features for some specific appliances.
+This text contains manual entries for non-obvious features of specific appliances.
 
-## Robotic vacuum cleaners (RVC)
+## Robotic Vacuum Cleaners (RVC)
 
 ### PUREi9
 
-The PUREi9.2 RVC supports the action `vacuum.send_command` with the command `clean_zones`, which allows for zone cleaning. The command expects two parameters: `map` which is the name of a map (as named in the Wellbeing app); and `zones` which is a list of zones to be cleaned. A zone (in the list) can either be the name of a zone to be cleaned (as a single string) or a dictionary containg the keys required key `name` and an optional key `power_mode` with values `[Quiet|Smart|Power]` to be used for the zone. If `power_mode`is not specified, the default power mode specified for that zone will be used.
+The PUREi9.2 RVC supports the action `vacuum.send_command` with the command `clean_zones`, which allows for zone cleaning. The command expects two parameters: `map`, which is the name of a map (as named in the Wellbeing app), and `zones`, which is a list of zones to be cleaned. A zone in the list can either be the name of a zone to be cleaned (as a single string) or a dictionary containing the required key `name` and an optional key `power_mode` with values `[Quiet|Smart|Power]` to be used for the zone. If `power_mode` is not specified, the default power mode specified for that zone will be used.
 
 #### Example 1
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,0 +1,39 @@
+# Electrolux Wellbeing - Manual
+
+This text contains manual entries for non-obvious features for some specific appliances.
+
+## Robotic vacuum cleaners (RVC)
+
+### PUREi9
+
+The PUREi9.2 RVC supports the action `vacuum.send_command` with the command `clean_zones`, which allows for zone cleaning. The command expects two parameters: `map` which is the name of a map (as named in the Wellbeing app); and `zones` which is a list of zones to be cleaned. A zone (in the list) can either be the name of a zone to be cleaned (as a single string) or a dictionary containg the keys required key `name` and an optional key `power_mode` with values `[Quiet|Smart|Power]` to be used for the zone. If `power_mode`is not specified, the default power mode specified for that zone will be used.
+
+#### Example 1
+
+```
+action: vacuum.send_command
+data:
+  command: clean_zones
+  params:
+    map: Downstairs
+    zones:
+      - Living room
+      - Kitchen
+target:
+  entity_id: r2d2_robotstatus
+```
+
+#### Example 2
+
+```
+action: vacuum.send_command
+data:
+  command: clean_zones
+  params:
+    map: Upstairs
+    zones:
+      - name: Bedroom
+        power_mode: Quiet
+target:
+  entity_id: c3po_robotstatus
+```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A custom component designed for [Home Assistant](https://www.home-assistant.io) 
     - 6000 Robot Vacuum Cleaner
     - 7000 Robot Vacuum Cleaner
 
-For special capabilities of specific appliances, please refer to the[brief manual](MANUAL.md).
+For special capabilities of specific appliances, please refer to the [brief manual](MANUAL.md).
 
 ### Install with HACS (recommended)
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ A custom component designed for [Home Assistant](https://www.home-assistant.io) 
     - PUREi9
     - PUREi9.2
 
-- Electrolux PUREi9 Vacuum Robot
-    - PUREi9
-    - PUREi9.2
-
 - Electrolux 600/700 Series Vacuum Robot
     - Clean 600
     - Hygienic 600
@@ -66,6 +62,7 @@ A custom component designed for [Home Assistant](https://www.home-assistant.io) 
     - 6000 Robot Vacuum Cleaner
     - 7000 Robot Vacuum Cleaner
 
+For special capabilities of specific appliances, please refer to the[brief manual](MANUAL.md).
 
 ### Install with HACS (recommended)
 


### PR DESCRIPTION
## What

### Code

The PR implements the `clean_zones` command for the PUREi9 RVCs. The base syntax of the command and parameters is compatible with the syntax of [home-assistant-purei9](https://github.com/Ekman/home-assistant-pure-i9/tree/master). That said, I wanted to provide the full capabilities, which for the PUREi9 also includes setting the `power_mode`. Hence, a `zones` zone can be either specified by only the name of the zone or with a dict that contains the `name` and optionally the `power_mode` of the zone. If no power mode is provided, the default specified in the map is used.

The code utilizes `voluptuous` (as the rest of HA) to validate the user-supplied parameters. It reports back errors using the `ServiceValidationError` as specified in the [HA developers' documentation](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/action-exceptions/). This provides user-interpretable error messages for syntax errors in the GUI. I've done extensive testing and hope that I covered even the corner cases with this.

### Manual

Since the usage of the command is non-trivial, I created a small manual alongside `README.md` to explain its usage. It is listed after the device list in `README.md` (where I also removed a duplicate entry). Please let me know if you would like this information elsewhere, or feel free to modify it as needed. 

## Caveats and discussions

Several design choices were not immediately apparent, and I could use a second opinion.

### Power mode naming

The power modes are now set using the `power_mode` parameter. The options are `[Quiet|Smart|Power]` (strings with the first letter capitalized). The syntax for the power modes is taken from the [Electrolux developer docs](https://developer.electrolux.one/documentation/reference#getMemoryMaps). That said, I am not entirely satisfied with the capitalization when used as a parameter. The Electrolux API for the PUREi9 takes an integer for the power mode, so I was considering making it an integer in HA as well. Still, since the 700 series takes a `vacuumMode` parameter with options `[quiet| energySaving|standard|powerful]` (supplied as strings to the Electrolux API, with camelCase), we will eventually have to convert from strings to numbers anyway if we wish consistency in HA.

I see at least three reasonable options for the naming convention.
1. As it is now, with capitalized strings following the Electrolux API conventions.
2. Making all strings that the user sees lowercase (or possibly snake case when it comes to the 700 series)
3. Making the case checking logic case agnostic and letting the user decide what looks best in the YAML
I understand that it is pedantic and subjective, but any input would be appreciated. It would be beneficial to settle on this before incorporating the code, as future changes to this may break already created actions.

I was also considering naming the option simply `mode` instead of `power_mode` to create some similarity with the `vacuumMode` option for the 700 series vacuums, as discussed below.

### 700 series implementation

The code only implements the functionality for the PUREi9 RVC since I do not have a 700 series RVC to test with. That said, I have been reviewing the 700 series documentation to ensure the (hopefully) upcoming implementation is as smooth as possible. Although it does not directly relate to this PR, it is beneficial to look ahead.

I see two different ways of implementing the corresponding functionality for the 700 series.

1. Recognizing that the capabilities of the 700 are different, and implementing a new command `clean_rooms` that more closely corresponds to those, acknowledging the differing terminology (`rooms` versus `zones`), and the greatly expanded set of options per room. It may also be more intuitive for some users if the Wellbeing app uses different terminology.

2. Expand `clean_zones` by adding additional options to the `zones` params schema to map to RVC functionality, such as `vacuumMode`, `sweepMode`, `waterPumpRate`, and `numberOfCleaningRepetitions`. The fact that Electrolux now refers to the zones as rooms would be hidden from the HA user, and `vacuumMode` and `power_mode` could potentially be combined into a single `mode` option.

Input is appreciated. Once the current PR is handled, I can create a local branch with the 700 series functionality to guide implementation, which can then be tested once an owner of such an appliance requests it. Since these vacuums are not handled by the home-assistant-purei9 integration, it would be a unique feature.