### PR TITLE
Fix for Gordias RVC start, stop, pause, and return_to_base

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -609,7 +609,7 @@ class WellbeingApiClient:
             return
         data = {}
         match Model(appliance.type):
-            case Model.Robot700series.value:
+            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
                 data = {"cleaningCommand": "startGlobalClean"}
             case Model.PUREi9.value:
                 data = {"CleaningCommand": "play"}
@@ -624,7 +624,7 @@ class WellbeingApiClient:
             return
         data = {}
         match Model(appliance.type):
-            case Model.Robot700series.value:
+            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
                 data = {"cleaningCommand": "stopClean"}
             case Model.PUREi9.value:
                 data = {"CleaningCommand": "stop"}
@@ -639,7 +639,7 @@ class WellbeingApiClient:
             return
         data = {}
         match Model(appliance.type):
-            case Model.Robot700series.value:
+            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
                 data = {"cleaningCommand": "pauseClean"}
             case Model.PUREi9.value:
                 data = {"CleaningCommand": "pause"}
@@ -654,7 +654,7 @@ class WellbeingApiClient:
             return
         data = {}
         match Model(appliance.type):
-            case Model.Robot700series.value:
+            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
                 data = {"cleaningCommand": "startGoToCharger"}
             case Model.PUREi9.value:
                 data = {"CleaningCommand": "home"}

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -539,7 +539,7 @@ class Appliance:
     @property
     def battery_range(self) -> tuple[int, int]:
         match Model(self.model):
-            case Model.Robot700series.value:
+            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
                 return 1, 100
             case Model.PUREi9.value:
                 return 2, 6  # Do not include lowest value of 1 to make this mean empty (0%) battery

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -539,7 +539,7 @@ class Appliance:
     @property
     def battery_range(self) -> tuple[int, int]:
         match Model(self.model):
-            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
                 return 1, 100
             case Model.PUREi9.value:
                 return 2, 6  # Do not include lowest value of 1 to make this mean empty (0%) battery
@@ -609,7 +609,7 @@ class WellbeingApiClient:
             return
         data = {}
         match Model(appliance.type):
-            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
                 data = {"cleaningCommand": "startGlobalClean"}
             case Model.PUREi9.value:
                 data = {"CleaningCommand": "play"}
@@ -624,7 +624,7 @@ class WellbeingApiClient:
             return
         data = {}
         match Model(appliance.type):
-            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
                 data = {"cleaningCommand": "stopClean"}
             case Model.PUREi9.value:
                 data = {"CleaningCommand": "stop"}
@@ -639,7 +639,7 @@ class WellbeingApiClient:
             return
         data = {}
         match Model(appliance.type):
-            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
                 data = {"cleaningCommand": "pauseClean"}
             case Model.PUREi9.value:
                 data = {"CleaningCommand": "pause"}
@@ -654,7 +654,7 @@ class WellbeingApiClient:
             return
         data = {}
         match Model(appliance.type):
-            case Model.Robot700series.value | Model.UltimateHome700.value | Model.VacuumHygienic700.value:
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
                 data = {"cleaningCommand": "startGoToCharger"}
             case Model.PUREi9.value:
                 data = {"CleaningCommand": "home"}


### PR DESCRIPTION
Though I might as well suggest this simple fix for the [issue mentioned here](https://github.com/JohNan/homeassistant-wellbeing/issues/161#issuecomment-2726355151), in case you wanted that to make the pre-release. I checked against the return data posted earlier under Issue #161 and am sure that this should work. This is a branch of the current main, and not my recent PR for zone cleaning. That said, the changes are in different places and should not cause collisions.