### PR TITLE
Vacuum fan speed

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -704,18 +704,14 @@ class WellbeingApiClient:
         if appliance is None:
             _LOGGER.error(f"Failed to set fan speed for appliance with id {pnc_id}")
             return
-        # data = {}
         match Model(appliance.type):
             case Model.Robot700series.value | Model.VacuumHygienic700.value:
-                # data = {"vacuumMode": FAN_SPEEDS_700SERIES.get(speed)}
                 result = await appliance.send_command({"vacuumMode": FAN_SPEEDS_700SERIES.get(speed)})
             case Model.PUREi9.value:
-                # data = {"powerMode": FAN_SPEEDS_PUREI9.get(speed)}
                 result = await appliance.send_command({"powerMode": FAN_SPEEDS_PUREI9.get(speed)})
             case _:
                 _LOGGER.error(f"Failed to set fan speed for unsupported appliance model {appliance.type}")
                 return
-        # result = await appliance.send_command(data)
         _LOGGER.debug(f"Set Vacuum Fan Speed: {result}")
 
     async def vacuum_send_command(self, pnc_id: str, command: str, params: dict | None = None):

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -39,7 +39,7 @@ FILTER_TYPE = {
 }
 
 # Schemas for definition of an interactive map and its zones for the PUREi9 vacuum cleaner.
-PUREI9_FAN_SPEEDS = {
+FAN_SPEEDS_PUREI9 = {
     "quiet": 1,
     "smart": 2,
     "power": 3,
@@ -48,7 +48,7 @@ PUREI9_FAN_SPEEDS = {
 INTERACTIVE_MAP_ZONE_SCHEMA = vol.Schema(
     {
         vol.Required("zone"): str,
-        vol.Optional("fan_speed"): vol.In(list(PUREI9_FAN_SPEEDS.keys())),
+        vol.Optional("fan_speed"): vol.In(list(FAN_SPEEDS_PUREI9.keys())),
     }
 )
 
@@ -69,6 +69,13 @@ INTERACTIVE_MAP_SCHEMA = vol.Schema(
         vol.Required("zones"): [validate_vacuum_zone_entry],
     }
 )
+
+FAN_SPEEDS_700SERIES = {
+    "quiet": "quiet",
+    "eco": "energySaving",
+    "standard": "standard",
+    "power": "powerful",
+}
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -491,6 +498,8 @@ class Appliance:
             self.louver_swing_mode = LouverSwingMode(data.get("LouverSwing"))
         if "powerMode" in data:
             self.power_mode = data.get("powerMode")
+        if "vacuumMode" in data:
+            self.vacuum_mode = data.get("vacuumMode")
         if "batteryStatus" in data:
             self.battery_status = data.get("batteryStatus")
 
@@ -544,6 +553,34 @@ class Appliance:
             case Model.PUREi9.value:
                 return 2, 6  # Do not include lowest value of 1 to make this mean empty (0%) battery
         return 0, 0
+
+    @property
+    def vacuum_fan_speed_list(self) -> list[str]:
+        """Return the available fan speeds for the vacuum cleaner."""
+        match Model(self.model):
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
+                return list(FAN_SPEEDS_700SERIES.keys())
+            case Model.PUREi9.value:
+                return list(FAN_SPEEDS_PUREI9.keys())
+        return []
+
+    @property
+    def vacuum_fan_speed(self) -> str | None:
+        """Return the current fan speed of the vacuum cleaner."""
+        match Model(self.model):
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
+                return next((speed for speed, mode in FAN_SPEEDS_700SERIES.items() if mode == self.vacuum_mode), None)
+            case Model.PUREi9.value:
+                return next((speed for speed, mode in FAN_SPEEDS_PUREI9.items() if mode == self.power_mode), None)
+        return None
+
+    def vacuum_set_fan_speed(self, speed: str) -> None:
+        """Set the current fan speed of the vacuum cleaner."""
+        match Model(self.model):
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
+                self.vacuum_mode = FAN_SPEEDS_700SERIES.get(speed, self.vacuum_mode)
+            case Model.PUREi9.value:
+                self.power_mode = FAN_SPEEDS_PUREI9.get(speed, self.power_mode)
 
 
 class Appliances:
@@ -661,6 +698,26 @@ class WellbeingApiClient:
         result = await appliance.send_command(data)
         _LOGGER.debug(f"Vacuum return to base command: {result}")
 
+    async def vacuum_set_fan_speed(self, pnc_id: str, speed: str):
+        """Set the fan speed of a vacuum cleaner."""
+        appliance = self._api_appliances.get(pnc_id, None)
+        if appliance is None:
+            _LOGGER.error(f"Failed to set fan speed for appliance with id {pnc_id}")
+            return
+        # data = {}
+        match Model(appliance.type):
+            case Model.Robot700series.value | Model.VacuumHygienic700.value:
+                # data = {"vacuumMode": FAN_SPEEDS_700SERIES.get(speed)}
+                result = await appliance.send_command({"vacuumMode": FAN_SPEEDS_700SERIES.get(speed)})
+            case Model.PUREi9.value:
+                # data = {"powerMode": FAN_SPEEDS_PUREI9.get(speed)}
+                result = await appliance.send_command({"powerMode": FAN_SPEEDS_PUREI9.get(speed)})
+            case _:
+                _LOGGER.error(f"Failed to set fan speed for unsupported appliance model {appliance.type}")
+                return
+        # result = await appliance.send_command(data)
+        _LOGGER.debug(f"Set Vacuum Fan Speed: {result}")
+
     async def vacuum_send_command(self, pnc_id: str, command: str, params: dict | None = None):
         """Send a command to the vacuum cleaner. Currently not used for any specific command."""
 
@@ -689,7 +746,7 @@ class WellbeingApiClient:
                 zones_payload.append(
                     {
                         "zoneId": api_zone.id,
-                        "powerMode": PUREI9_FAN_SPEEDS.get(zone.get("fan_speed"), api_zone.power_mode),
+                        "powerMode": FAN_SPEEDS_PUREI9.get(zone.get("fan_speed"), api_zone.power_mode),
                     }
                 )
             command_payload = {"CustomPlay": {"persistentMapId": api_map.id, "zones": zones_payload}}

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -704,15 +704,14 @@ class WellbeingApiClient:
         if appliance is None:
             _LOGGER.error(f"Failed to set fan speed for appliance with id {pnc_id}")
             return
+        data = dict[str, str | int | None]()
         match Model(appliance.type):
             case Model.Robot700series.value | Model.VacuumHygienic700.value:
-                result = await appliance.send_command({"vacuumMode": FAN_SPEEDS_700SERIES.get(speed)})
+                data = {"vacuumMode": FAN_SPEEDS_700SERIES.get(speed)}
             case Model.PUREi9.value:
-                result = await appliance.send_command({"powerMode": FAN_SPEEDS_PUREI9.get(speed)})
-            case _:
-                _LOGGER.error(f"Failed to set fan speed for unsupported appliance model {appliance.type}")
-                return
-        _LOGGER.debug(f"Set Vacuum Fan Speed: {result}")
+                data = {"powerMode": FAN_SPEEDS_PUREI9.get(speed)}
+        result = await appliance.send_command(data)
+        _LOGGER.debug(f"Set Fan Speed command: {result}")
 
     async def vacuum_send_command(self, pnc_id: str, command: str, params: dict | None = None):
         """Send a command to the vacuum cleaner. Currently not used for any specific command."""

--- a/custom_components/wellbeing/vacuum.py
+++ b/custom_components/wellbeing/vacuum.py
@@ -19,6 +19,7 @@ SUPPORTED_FEATURES = (
     | VacuumEntityFeature.PAUSE
     | VacuumEntityFeature.RETURN_HOME
     | VacuumEntityFeature.BATTERY
+    | VacuumEntityFeature.FAN_SPEED
     | VacuumEntityFeature.SEND_COMMAND
 )
 
@@ -119,6 +120,16 @@ class WellbeingVacuum(WellbeingEntity, StateVacuumEntity):
         else:
             return "mdi:battery-unknown"
 
+    @property
+    def fan_speed(self):
+        """Return the current fan speed of the vacuum."""
+        return self.get_appliance.vacuum_fan_speed
+
+    @property
+    def fan_speed_list(self):
+        """Return the list of available fan speeds."""
+        return self.get_appliance.vacuum_fan_speed_list
+
     async def async_start(self):
         """Start the vacuum cleaner."""
         await self.api.vacuum_start(self.pnc_id)
@@ -134,6 +145,14 @@ class WellbeingVacuum(WellbeingEntity, StateVacuumEntity):
     async def async_return_to_base(self):
         """Return the vacuum cleaner to its base."""
         await self.api.vacuum_return_to_base(self.pnc_id)
+
+    async def async_set_fan_speed(self, fan_speed: str) -> None:
+        """Set the fan speed of the vacuum cleaner."""
+        await self.api.vacuum_set_fan_speed(self.pnc_id, fan_speed)
+        self.get_appliance.vacuum_set_fan_speed(
+            fan_speed
+        )  # Optimistically update the state before the next coordinator refresh
+        self.async_write_ha_state()
 
     async def async_send_command(self, command: str, params: dict[str, Any] | None = None, **kwargs: Any) -> None:
         """Send a custom command to the vacuum cleaner."""


### PR DESCRIPTION
Electrolux has now (after quite some time) updated the API backend to support setting the power mode (i.e., fan speed) for the PUREi9 RVC. This PR now adds the functionality to set the fan speed for the PUREi9 (and hopefully the 700 series as well) from HA. I tried to add localization to the strings for fan speeds, but could not for the life of me get that to work.

![fan_mode](https://github.com/user-attachments/assets/839a628c-7167-49d3-8a3d-0f0f84321372)