### PR TITLE
Fixes UI fan speed setting on orginal purei9

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -739,11 +739,7 @@ class WellbeingApiClient:
                 if hasattr(appliance, "power_mode"):
                     data = {"powerMode": FAN_SPEEDS_PUREI92.get(speed)}
                 if hasattr(appliance, "eco_mode"):
-                    # data = {"ecoMode": FAN_SPEEDS_PUREI9.get(speed)}
-                    if speed == "eco":
-                        data = {"powerMode": 1}
-                    else:
-                        data = {"powerMode": 3}
+                    data = {"ecoMode": FAN_SPEEDS_PUREI9.get(speed)}
         result = await api_appliance.send_command(data)
         _LOGGER.debug(f"Set Fan Speed command: {result}")
         appliance.vacuum_set_fan_speed(speed)


### PR DESCRIPTION
I received feedback from the Electrolux developers today stating that "Now you should be able to set ecoMode: true / ecoMode: false on purei9 as well." This PR re-implements the ecoMode setting and should finalize the fan speed implementation by (hopefully) enabling the vacuum fan speed for the original purei9 to be set in the UI. This functionality was previously broken due to the prior limitation in the Electrolux api.

Since I do not have access to the original purei9, it would be valuable if @drgreenbaum or @michaelfuncke (or someone else) could test the functionality to make sure it works.