### PR TITLE
Moved deprecated vacuum battery properties to separate sensor

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -324,7 +324,16 @@ class Appliance:
             ),
         ]
 
-        purei9_entities = [
+        vacuum_common = [
+            ApplianceSensor(
+                name="Battery",
+                attr="batteryStatus",
+                device_class=SensorDeviceClass.BATTERY,
+                unit=PERCENTAGE,
+            ),
+        ]
+
+        vacuum_purei9_entities = [
             ApplianceVacuum(
                 name=data.get("applianceName", "Vacuum"),
                 attr="robotStatus",
@@ -468,7 +477,8 @@ class Appliance:
             + a7_entities
             + pure500_entities
             + pm700_entities
-            + purei9_entities
+            + vacuum_common
+            + vacuum_purei9_entities
             + ultimate_home_700_entities
             + vacuum_700_series_entities
             + vacuum_hygienic_700_entities
@@ -508,8 +518,6 @@ class Appliance:
             self.eco_mode = data.get("ecoMode")
         if "vacuumMode" in data:
             self.vacuum_mode = data.get("vacuumMode")
-        if "batteryStatus" in data:
-            self.battery_status = data.get("batteryStatus")
 
         self.capabilities = capabilities
         self.entities = [entity.setup(data) for entity in Appliance._create_entities(data) if entity.attr in data]
@@ -560,7 +568,7 @@ class Appliance:
                 return 1, 100
             case Model.PUREi9.value:
                 return 2, 6  # Do not include lowest value of 1 to make this mean empty (0%) battery
-        return 0, 0
+        return 1, 100  # Default battery range
 
     @property
     def vacuum_fan_speed_list(self) -> list[str]:

--- a/custom_components/wellbeing/sensor.py
+++ b/custom_components/wellbeing/sensor.py
@@ -2,7 +2,8 @@
 
 from typing import cast
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
+from homeassistant.util.percentage import ranged_value_to_percentage
 from homeassistant.const import Platform
 
 from .api import ApplianceSensor
@@ -32,6 +33,11 @@ class WellbeingSensor(WellbeingEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
+        if self.device_class == SensorDeviceClass.BATTERY:
+            return ranged_value_to_percentage(
+                self.get_appliance.battery_range,
+                self.get_entity.state,
+            )
         return self.get_entity.state
 
     @property


### PR DESCRIPTION
As of 2025.8 the ``StateVacuumEntity``, ``battery_level`` and ``battery_icon``, have been deprecated. They should be replaced by a separate sensor with the ``battery sensor`` device class, see [recent development post](https://developers.home-assistant.io/blog/2025/07/02/vacuum-battery-properties-deprecated/)

The PR implements this change for all supported robot vacuums, and also solves issues #196 and #200.

I let HA use the default icon for the battery sensor (which does show the battery charge level). The good thing with this is that the code should be more maintainable without the integration-specific icon-selection logic. The bad thing is that the small charge lightning bolt on the icon is now gone (although the charge status was, to be honest, guessed in the prior implementation). One could potentially add a ``charging`` binary sensor as suggested in the development post, but it is not completely clear how to map states (``robotStatus`` on purei9 and ``chargingStatus`` on 700 series) to such a binary sensor, and since these attributes are already exposed in raw form all information can be inferred anyway in automations so I did not bother with that.

The range of the ``batteryStatus`` attribute depends on the model (1 to 6 for purei9 and 1 to 100 for the 700 series), so I had to alter the code in ``sensor.py`` to treat the ``battery sensor`` device class specially. I hope this is ok with you. Otherwise, the battery level is not displayed correctly in HA across all models. The range code is the same as before, though, and should thus work across all previously supported vacuum models just as before.
