### PR TITLE
Update pyelectroluxgroup and implement livestream polling

### DIFF
--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -38,12 +38,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if hass.data.get(DOMAIN) is None:
         hass.data.setdefault(DOMAIN, {})
 
-    if entry.options.get(CONF_STREAM, DEFAULT_STREAM):
-        update_interval = None
-    elif entry.options.get(CONF_SCAN_INTERVAL):
-        update_interval = timedelta(seconds=entry.options[CONF_SCAN_INTERVAL])
+    if entry.options.get(CONF_SCAN_INTERVAL):
+        base_interval = entry.options[CONF_SCAN_INTERVAL]
     else:
-        update_interval = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
+        base_interval = DEFAULT_SCAN_INTERVAL
+
+    if entry.options.get(CONF_STREAM, DEFAULT_STREAM):
+        update_interval = timedelta(seconds=base_interval * 5)
+    else:
+        update_interval = timedelta(seconds=base_interval)
 
     token_manager = WellBeingTokenManager(hass, entry)
     try:

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.components.vacuum import Segment
+import copy
 from pyelectroluxgroup.api import ElectroluxHubAPI
 from pyelectroluxgroup.appliance import Appliance as ApiAppliance
 import voluptuous as vol
@@ -735,6 +736,7 @@ class WellbeingApiClient:
         self._api_appliances: dict[str, ApiAppliance] = {}
         self._hub = hub
         self._load_lock = asyncio.Lock()
+        self._livestream_properties: dict[str, list[str]] = {}
 
     async def _ensure_loaded(self) -> None:
         if self._api_appliances:
@@ -744,6 +746,17 @@ class WellbeingApiClient:
                 return
             appliances: list[ApiAppliance] = await self._hub.async_get_appliances()
             self._api_appliances = {appliance.id: appliance for appliance in appliances}
+
+            try:
+                livestream_configs = await self._hub.async_get_livestream_configurations()
+                for appliance_config in livestream_configs.get("appliances", []):
+                    appliance_id = appliance_config.get("applianceId")
+                    properties = appliance_config.get("properties", [])
+                    if appliance_id and properties:
+                        self._livestream_properties[appliance_id] = properties
+                        _LOGGER.debug(f"Appliance {appliance_id} supports livestreaming for properties: {properties}")
+            except Exception as e:
+                _LOGGER.warning(f"Failed to fetch livestream configurations: {e}")
 
     def update_appliance_state(self, ha_appliances, appliance_id, property_name, value):
         appliance = self._api_appliances.get(appliance_id)
@@ -778,7 +791,21 @@ class WellbeingApiClient:
         await self._ensure_loaded()
         found_appliances = {}
         for appliance in (appliance for appliance in self._api_appliances.values()):
-            await appliance.async_update()
+            livestream_props = self._livestream_properties.get(appliance.id, [])
+            # Only restore livestream properties if the appliance is actually connected to the livestream
+            # The connection state is updated by the live stream itself
+            is_streaming = appliance.state_data.get("connectionState") == "Connected"
+
+            if not livestream_props or not is_streaming:
+                await appliance.async_update()
+            else:
+                original_state = copy.deepcopy(appliance.state_data)
+                await appliance.async_update()
+
+                if "properties" in appliance.state_data and "reported" in appliance.state_data["properties"]:
+                    for prop in livestream_props:
+                        if "properties" in original_state and "reported" in original_state["properties"] and prop in original_state["properties"]["reported"]:
+                            appliance.state_data["properties"]["reported"][prop] = original_state["properties"]["reported"][prop]
 
             model_name = appliance.type
             appliance_id = appliance.id

--- a/custom_components/wellbeing/manifest.json
+++ b/custom_components/wellbeing/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/JohNan/homeassistant-wellbeing/issues",
   "loggers": ["pyelectroluxgroup"],
-  "requirements": ["pyelectroluxgroup==0.2.6"],
+  "requirements": ["pyelectroluxgroup==0.2.7"],
   "version": "v0.0.0"
 }


### PR DESCRIPTION
- Bumped pyelectroluxgroup version to 0.2.7 in manifest.json.
- Modified __init__.py to allow background polling at a reduced interval (5x base interval) when the live stream is enabled. This ensures that non-streamed properties are still updated.
- Updated api.py to fetch and cache livestream configurations using `async_get_livestream_configurations()`.
- Added state protection logic during polling: if an appliance is actively streaming, its livestreamed properties are backed up and restored after `async_update()` to prevent stale polling data from overwriting fresh live stream updates.

---
*PR created automatically by Jules for task [13405572340078729686](https://jules.google.com/task/13405572340078729686) started by @JohNan*