### PR TITLE
Fix entity_id domain to resolve HA warnings

### DIFF
--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -19,7 +19,13 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from .api import WellbeingApiClient
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, CONF_REFRESH_TOKEN, CONF_STREAM, DEFAULT_STREAM
+from .const import (
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    CONF_REFRESH_TOKEN,
+    CONF_STREAM,
+    DEFAULT_STREAM,
+)
 from .const import DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -65,7 +71,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await coordinator.async_config_entry_first_refresh()
 
     if entry.options.get(CONF_STREAM, DEFAULT_STREAM):
-        entry.async_create_background_task(hass, coordinator._listen_for_changes(), "wellbeing_stream")
+        entry.async_create_background_task(
+            hass, coordinator._listen_for_changes(), "wellbeing_stream"
+        )
 
     if not coordinator.last_update_success:
         raise ConfigEntryNotReady from coordinator.last_exception
@@ -123,7 +131,9 @@ class WellbeingDataUpdateCoordinator(DataUpdateCoordinator):
             if not appliance_id or not property_name:
                 continue
 
-            if self.api.update_appliance_state(self.data["appliances"], appliance_id, property_name, value):
+            if self.api.update_appliance_state(
+                self.data["appliances"], appliance_id, property_name, value
+            ):
                 self.async_set_updated_data(self.data)
 
 

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -748,13 +748,17 @@ class WellbeingApiClient:
             self._api_appliances = {appliance.id: appliance for appliance in appliances}
 
             try:
-                livestream_configs = await self._hub.async_get_livestream_configurations()
+                livestream_configs = (
+                    await self._hub.async_get_livestream_configurations()
+                )
                 for appliance_config in livestream_configs.get("appliances", []):
                     appliance_id = appliance_config.get("applianceId")
                     properties = appliance_config.get("properties", [])
                     if appliance_id and properties:
                         self._livestream_properties[appliance_id] = properties
-                        _LOGGER.debug(f"Appliance {appliance_id} supports livestreaming for properties: {properties}")
+                        _LOGGER.debug(
+                            f"Appliance {appliance_id} supports livestreaming for properties: {properties}"
+                        )
             except Exception as e:
                 _LOGGER.warning(f"Failed to fetch livestream configurations: {e}")
 
@@ -772,7 +776,9 @@ class WellbeingApiClient:
                 appliance.state_data["properties"]["reported"] = {}
             appliance.state_data["properties"]["reported"][property_name] = value
 
-        _LOGGER.debug(f"Live stream update for {appliance_id}: {property_name} = {value}")
+        _LOGGER.debug(
+            f"Live stream update for {appliance_id}: {property_name} = {value}"
+        )
 
         ha_appliance = ha_appliances.get_appliance(appliance_id)
         if ha_appliance is not None:
@@ -802,10 +808,19 @@ class WellbeingApiClient:
                 original_state = copy.deepcopy(appliance.state_data)
                 await appliance.async_update()
 
-                if "properties" in appliance.state_data and "reported" in appliance.state_data["properties"]:
+                if (
+                    "properties" in appliance.state_data
+                    and "reported" in appliance.state_data["properties"]
+                ):
                     for prop in livestream_props:
-                        if "properties" in original_state and "reported" in original_state["properties"] and prop in original_state["properties"]["reported"]:
-                            appliance.state_data["properties"]["reported"][prop] = original_state["properties"]["reported"][prop]
+                        if (
+                            "properties" in original_state
+                            and "reported" in original_state["properties"]
+                            and prop in original_state["properties"]["reported"]
+                        ):
+                            appliance.state_data["properties"]["reported"][prop] = (
+                                original_state["properties"]["reported"][prop]
+                            )
 
             model_name = appliance.type
             appliance_id = appliance.id

--- a/custom_components/wellbeing/config_flow.py
+++ b/custom_components/wellbeing/config_flow.py
@@ -14,7 +14,13 @@ from pyelectroluxgroup.api import ElectroluxHubAPI
 from pyelectroluxgroup.token_manager import TokenManager
 
 from . import CONF_REFRESH_TOKEN
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, CONFIG_FLOW_TITLE, CONF_STREAM, DEFAULT_STREAM
+from .const import (
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    CONFIG_FLOW_TITLE,
+    CONF_STREAM,
+    DEFAULT_STREAM,
+)
 from .const import DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -57,7 +63,9 @@ class WellbeingFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
             options = {CONF_STREAM: user_input.pop(CONF_STREAM, DEFAULT_STREAM)}
 
-            return self.async_create_entry(title=CONFIG_FLOW_TITLE, data=user_input, options=options)
+            return self.async_create_entry(
+                title=CONFIG_FLOW_TITLE, data=user_input, options=options
+            )
 
         return await self._show_config_form(user_input)
 

--- a/custom_components/wellbeing/entity.py
+++ b/custom_components/wellbeing/entity.py
@@ -1,6 +1,5 @@
 """WellbeingEntity class"""
 
-from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
@@ -26,9 +25,8 @@ class WellbeingEntity(CoordinatorEntity):
         self.entity_type = entity_type
         self.config_entry = config_entry
         self.pnc_id = pnc_id
-        self.entity_id = ENTITY_ID_FORMAT.format(
-            slugify(f"{DEFAULT_NAME}_{self.get_appliance.name}_{self.entity_attr}")
-        )
+        expected_domain = self.__class__.__module__.split(".")[-1]
+        self.entity_id = f"{expected_domain}.{slugify(f'{DEFAULT_NAME}_{self.get_appliance.name}_{self.entity_attr}')}"
 
     @property
     def name(self):


### PR DESCRIPTION
This fixes a deprecation warning introduced in Home Assistant regarding entity domains not matching the platform domain. The `WellbeingEntity` previously explicitly set its `entity_id` to start with `sensor.` using `ENTITY_ID_FORMAT` from `homeassistant.components.sensor`. This caused switches, fans, and binary sensors to incorrectly use the `sensor.` domain prefix.
This commit dynamically infers the expected domain for the `entity_id` based on the platform module that defined the entity.

---
*PR created automatically by Jules for task [370180676610127404](https://jules.google.com/task/370180676610127404) started by @JohNan*