### PR TITLE
Add a map camera entity for robot vacuums

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -4,6 +4,36 @@ This text contains manual entries for non-obvious features of specific appliance
 
 ## Robotic Vacuum Cleaners (RVC)
 
+### Vacuum map camera
+
+Robot vacuums whose appliance state reports dynamic map data (verified on the
+PUREi9.2) get a camera entity showing the map of the latest cleaning session:
+the covered area, the cleaning path, the charger and — while the robot is
+moving — the robot itself. The image updates on every API update, so it shows
+live progress during a cleaning session.
+
+The camera can be used with a plain picture-entity card, or with
+[xiaomi-vacuum-map-card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card):
+
+```yaml
+type: custom:xiaomi-vacuum-map-card
+entity: vacuum.your_robot
+vacuum_platform: default
+map_source:
+  camera: camera.your_robot_map
+calibration_source:
+  camera: true
+```
+
+The camera exposes a `calibration_points` attribute mapping the vacuum
+coordinate system (metres, persistent map frame) to image pixels, which the
+card consumes via `calibration_source: camera: true`.
+
+The map orientation can be adjusted with the "Vacuum map rotation" integration
+option (degrees counter-clockwise), for example to match the orientation shown
+in the Electrolux app.
+
+
 ### PUREi9
 
 The PUREi9.2 RVC supports the action `vacuum.send_command` with the command `clean_zones`, which allows for zone cleaning. The command expects two parameters: `map`, which is the name of a map (as named in the Wellbeing app), and `zones`, which is a list of zones to be cleaned. A zone in the list can either be the name of a zone to be cleaned (as a single string) or a dictionary containing the required key `zone` and an optional key `fan_speed` with values `power`, `quiet`, or `smart` to be used for the zone. If `fan_speed` is not specified, the default fan speed specified for that zone will be used.

--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -135,7 +135,12 @@ class WellbeingDataUpdateCoordinator(DataUpdateCoordinator):
             if self.api.update_appliance_state(
                 self.data["appliances"], appliance_id, property_name, value
             ):
-                self.async_set_updated_data(self.data)
+                # Notify entities without async_set_updated_data: that would
+                # reset the polling schedule, and a steady trickle of stream
+                # events (e.g. battery updates) would then postpone polling
+                # indefinitely, freezing all properties that only arrive via
+                # polling (such as the vacuum map data).
+                self.async_update_listeners()
 
 
 class WellBeingTokenManager(TokenManager):

--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -50,10 +50,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     else:
         base_interval = DEFAULT_SCAN_INTERVAL
 
+    # With the live stream enabled, polling is the slow path for full-state
+    # refreshes - but the stream does not carry every property (e.g. the
+    # vacuum map data only arrives via polling), so while a vacuum is active
+    # the coordinator polls at the base interval to follow the cleaning session.
     if entry.options.get(CONF_STREAM, DEFAULT_STREAM):
         update_interval = timedelta(seconds=base_interval * 5)
     else:
         update_interval = timedelta(seconds=base_interval)
+    active_update_interval = timedelta(seconds=base_interval)
 
     token_manager = WellBeingTokenManager(hass, entry)
     try:
@@ -66,7 +71,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     client = WellbeingApiClient(hub)
 
     coordinator = WellbeingDataUpdateCoordinator(
-        hass, client=client, update_interval=update_interval
+        hass,
+        client=client,
+        update_interval=update_interval,
+        active_update_interval=active_update_interval,
     )
 
     await coordinator.async_config_entry_first_refresh()
@@ -109,18 +117,41 @@ class WellbeingDataUpdateCoordinator(DataUpdateCoordinator):
         hass: HomeAssistant,
         client: WellbeingApiClient,
         update_interval: timedelta,
+        active_update_interval: timedelta | None = None,
     ) -> None:
         """Initialize."""
         self.api = client
+        self._idle_update_interval = update_interval
+        self._active_update_interval = active_update_interval or update_interval
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
 
     async def _async_update_data(self):
         """Update data via library."""
         try:
             appliances = await self.api.async_get_appliances()
+            self.update_interval = (
+                self._active_update_interval
+                if self._has_active_vacuum(appliances)
+                else self._idle_update_interval
+            )
             return {"appliances": appliances}
         except Exception as exception:
             raise UpdateFailed(exception) from exception
+
+    @staticmethod
+    def _has_active_vacuum(appliances) -> bool:
+        """Whether any robot vacuum is currently on a cleaning session."""
+        from homeassistant.components.vacuum import VacuumActivity
+
+        from .vacuum import VACUUM_ACTIVITIES  # local import, vacuum.py imports this module
+
+        active = {VacuumActivity.CLEANING, VacuumActivity.RETURNING, VacuumActivity.PAUSED}
+        return any(
+            VACUUM_ACTIVITIES.get(entity.state) in active
+            for appliance in appliances.appliances.values()
+            for entity in appliance.entities
+            if entity.entity_type == Platform.VACUUM
+        )
 
     async def _listen_for_changes(self):
         """Listen to live stream for changes."""

--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -30,6 +30,7 @@ from .const import DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 PLATFORMS = [
+    Platform.CAMERA,
     Platform.SENSOR,
     Platform.FAN,
     Platform.BINARY_SENSOR,

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -213,6 +213,13 @@ class ApplianceClimate(ApplianceEntity):
         super().__init__(name, attr)
 
 
+class ApplianceCamera(ApplianceEntity):
+    entity_type: int = Platform.CAMERA
+
+    def __init__(self, name, attr) -> None:
+        super().__init__(name, attr)
+
+
 class Appliance:
     serialNumber: str
     brand: str
@@ -222,6 +229,7 @@ class Appliance:
     entities: list
     capabilities: dict
     model: Model
+    reported_state: dict
 
     def __init__(self, name, pnc_id, model) -> None:
         self.model = Model(model)
@@ -383,6 +391,11 @@ class Appliance:
                 attr="batteryStatus",
                 device_class=SensorDeviceClass.BATTERY,
                 unit=PERCENTAGE,
+            ),
+            # Only created for robots whose state reports dynamic map data
+            ApplianceCamera(
+                name="Map",
+                attr="mapData",
             ),
         ]
 
@@ -582,6 +595,7 @@ class Appliance:
         self.mode = mode
 
     def setup(self, data, capabilities):
+        self.reported_state = data
         self.firmware = ""
         if "FrmVer_NIU" in data:
             self.firmware = data.get("FrmVer_NIU")

--- a/custom_components/wellbeing/camera.py
+++ b/custom_components/wellbeing/camera.py
@@ -1,0 +1,171 @@
+"""Camera platform for Wellbeing: renders the robot vacuum map.
+
+The Electrolux API does not provide a map image, but the appliance state of
+robot vacuums includes raw dynamic map data (see map_renderer). This platform
+renders that data into a camera entity, so the map can be shown in lovelace
+(e.g. with picture-entity or xiaomi-vacuum-map-card, which can also read the
+``calibration_points`` attribute via ``calibration_source: camera: true``).
+"""
+
+import logging
+
+from homeassistant.components.camera import Camera
+from homeassistant.components.vacuum import VacuumActivity
+from homeassistant.const import Platform
+
+from .const import CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION, DOMAIN
+from .entity import WellbeingEntity
+from .map_renderer import ROBOT_MARKER_CHARGER, ROBOT_MARKER_NONE, ROBOT_MARKER_POSE, MapImage, render_map
+from .vacuum import VACUUM_ACTIVITIES
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+ACTIVE_ACTIVITIES = {
+    VacuumActivity.CLEANING,
+    VacuumActivity.RETURNING,
+    VacuumActivity.PAUSED,
+}
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Setup camera platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    appliances = coordinator.data.get("appliances", None)
+
+    if appliances is not None:
+        async_add_devices(
+            [
+                WellbeingCamera(coordinator, entry, pnc_id, entity.entity_type, entity.attr)
+                for pnc_id, appliance in appliances.appliances.items()
+                for entity in appliance.entities
+                if entity.entity_type == Platform.CAMERA
+            ]
+        )
+
+
+class WellbeingCamera(WellbeingEntity, Camera):
+    """Camera showing the robot vacuum map."""
+
+    _attr_content_type = "image/png"
+
+    def __init__(self, coordinator, config_entry, pnc_id, entity_type, entity_attr):
+        super().__init__(coordinator, config_entry, pnc_id, entity_type, entity_attr)
+        Camera.__init__(self)
+        self._map_image: MapImage | None = None
+        self._render_key = None
+        self._crumbs: list = []
+        self._crumb_session = None
+        self._crumb_timestamp = None
+
+    @property
+    def map_data(self) -> dict:
+        return self.get_entity.state or {}
+
+    def _robot_marker(self) -> str:
+        """Where to draw the robot: at its pose (moving), on the charger (docked), or not at all.
+
+        The reported robot pose is only current while the robot is moving AND
+        the reported map data belongs to the running cleaning session: at the
+        start of a session the cloud still reports the previous session's map
+        (uploads lag minutes behind the robot), and drawing the old pose on
+        the old map would show the robot somewhere it is not.
+        """
+        vacuum = next(
+            (entity for entity in self.get_appliance.entities if entity.entity_type == Platform.VACUUM),
+            None,
+        )
+        if vacuum is None:
+            return ROBOT_MARKER_NONE
+        activity = VACUUM_ACTIVITIES.get(vacuum.state)
+        if activity in ACTIVE_ACTIVITIES:
+            if self._map_session_is_current():
+                return ROBOT_MARKER_POSE
+            return ROBOT_MARKER_NONE
+        # DOCKED covers charging/pitstop; the PUREi9 reports "sleeping"
+        # (status 10, mapped to IDLE) when it rests fully charged on the
+        # charger, so IDLE is treated as docked too.
+        if activity in (VacuumActivity.DOCKED, VacuumActivity.IDLE):
+            return ROBOT_MARKER_CHARGER
+        return ROBOT_MARKER_NONE
+
+    def _map_session_is_current(self) -> bool:
+        """Whether the reported map data belongs to the running cleaning session."""
+        session = getattr(self.get_appliance, "reported_state", {}).get("cleaningSession") or {}
+        session_id = session.get("sessionId")
+        if session_id is None:
+            return True  # cannot tell; keep the previous behaviour
+        return self.map_data.get("sessionId") == session_id
+
+    def _accumulated_crumbs(self, map_data: dict) -> list:
+        """Return the full crumb trail for the reported session.
+
+        When a live map view is open in the Electrolux app, the robot
+        switches to delta uploads (crumbCollectionDelta) where each state
+        carries only the crumbs since the previous upload, so they have to
+        be accumulated across updates. Non-delta uploads carry the full
+        trail and replace the accumulated state.
+        """
+        session_id = map_data.get("sessionId")
+        if session_id != self._crumb_session:
+            self._crumb_session = session_id
+            self._crumb_timestamp = None
+            self._crumbs = []
+        timestamp = map_data.get("timestamp")
+        if timestamp != self._crumb_timestamp:
+            self._crumb_timestamp = timestamp
+            crumbs = map_data.get("crumbs") or []
+            if map_data.get("crumbCollectionDelta"):
+                self._crumbs = self._crumbs + crumbs
+            else:
+                self._crumbs = crumbs
+        return self._crumbs
+
+    async def _async_render_if_changed(self) -> None:
+        """(Re)render the map when the underlying map data has changed."""
+        map_data = self.map_data
+        crumbs = self._accumulated_crumbs(map_data)
+        robot_marker = self._robot_marker()
+        rotation = self.config_entry.options.get(CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION)
+        render_key = (
+            map_data.get("timestamp"),
+            map_data.get("sessionId"),
+            len(crumbs),
+            robot_marker,
+            rotation,
+        )
+        if render_key == self._render_key:
+            return
+        map_image = await self.hass.async_add_executor_job(
+            render_map, {"mapData": {**map_data, "crumbs": crumbs}}, float(rotation), robot_marker
+        )
+        self._render_key = render_key
+        if map_image:
+            self._map_image = map_image
+
+    async def async_added_to_hass(self) -> None:
+        """Render once on startup so the image and attributes are available."""
+        await super().async_added_to_hass()
+        await self._async_render_if_changed()
+
+    def _handle_coordinator_update(self) -> None:
+        """Re-render in the background when the coordinator has new data."""
+        self.hass.async_create_task(self._async_render_and_write_state())
+
+    async def _async_render_and_write_state(self) -> None:
+        await self._async_render_if_changed()
+        self.async_write_ha_state()
+
+    async def async_camera_image(self, width: int | None = None, height: int | None = None) -> bytes | None:
+        """Return the rendered map image."""
+        await self._async_render_if_changed()
+        return self._map_image.image if self._map_image else None
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        attributes = super().extra_state_attributes
+        if self._map_image:
+            attributes["calibration_points"] = self._map_image.calibration_points
+        if timestamp := self.map_data.get("timestamp"):
+            attributes["map_timestamp"] = timestamp
+        return attributes

--- a/custom_components/wellbeing/config_flow.py
+++ b/custom_components/wellbeing/config_flow.py
@@ -18,7 +18,9 @@ from .const import (
     CONF_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     CONFIG_FLOW_TITLE,
+    CONF_MAP_ROTATION,
     CONF_STREAM,
+    DEFAULT_MAP_ROTATION,
     DEFAULT_STREAM,
 )
 from .const import DOMAIN
@@ -197,6 +199,12 @@ class WellbeingOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_STREAM, DEFAULT_STREAM
                         ),
                     ): bool,
+                    vol.Optional(
+                        CONF_MAP_ROTATION,
+                        default=self.config_entry.options.get(
+                            CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=0, max=359)),
                 }
             ),
         )

--- a/custom_components/wellbeing/const.py
+++ b/custom_components/wellbeing/const.py
@@ -12,8 +12,10 @@ CONF_ENABLED = "enabled"
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_STREAM = "stream"
+CONF_MAP_ROTATION = "map_rotation"
 
 # Defaults
 DEFAULT_NAME = DOMAIN
 DEFAULT_SCAN_INTERVAL = 60
 DEFAULT_STREAM = False
+DEFAULT_MAP_ROTATION = 0

--- a/custom_components/wellbeing/manifest.json
+++ b/custom_components/wellbeing/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/JohNan/homeassistant-wellbeing/issues",
   "loggers": ["pyelectroluxgroup"],
-  "requirements": ["pyelectroluxgroup==0.2.7"],
+  "requirements": ["Pillow>=10.1.0", "pyelectroluxgroup==0.2.7"],
   "version": "v0.0.0"
 }

--- a/custom_components/wellbeing/map_renderer.py
+++ b/custom_components/wellbeing/map_renderer.py
@@ -1,0 +1,260 @@
+"""Render robot vacuum map images from the raw map data in the appliance state.
+
+The Electrolux API reports dynamic map data for robot vacuums in the appliance
+state under ``mapData``: "crumbs" (points the robot has visited), the robot
+pose, the charger pose and per-chunk coordinate transforms. This module turns
+that data into a PNG image plus calibration points, without any additional API
+calls.
+
+Coordinates: crumbs are recorded in per-chunk local frames; each crumb's ``t``
+selects a transform ``(tx, ty, a)`` and ``global = R(-a) @ (p - (tx, ty))``.
+Frame 0's origin maps exactly onto the reported charger pose, which is how
+this convention was verified (on a PUREi9.2). The charger pose and the robot
+pose are already in the global (persistent map) frame; the robot pose
+coincides with the last reported crumb.
+
+The calibration points map the global (metres) frame to image pixels in the
+format used by mqtt_vacuum_camera, so lovelace cards such as
+xiaomi-vacuum-map-card can consume them via ``calibration_source: camera``.
+
+All functions in this module are synchronous and CPU-bound; call them from an
+executor.
+"""
+
+from dataclasses import dataclass, field
+import io
+import math
+
+from PIL import Image, ImageDraw
+
+SCALE = 120  # px per metre (before supersampling)
+SUPERSAMPLE = 2
+PADDING_M = 0.7
+ROBOT_WIDTH_M = 0.33  # PUREi9 footprint -> width of the coverage swath
+MAX_SEGMENT_M = 0.6  # crumb gaps larger than this are lifts/jumps, not moves
+MAX_DIMENSION_PX = 1600  # safety cap for degenerate map data
+
+ROBOT_MARKER_NONE = "none"
+ROBOT_MARKER_POSE = "pose"
+ROBOT_MARKER_CHARGER = "charger"
+
+BACKGROUND = (17, 20, 24, 255)
+SWATH = (46, 92, 158, 255)
+PATH = (137, 180, 250, 255)
+CHARGER = (52, 211, 153, 255)
+ROBOT_FILL = (255, 255, 204, 255)
+ROBOT_OUTLINE = (127, 127, 102, 255)
+
+
+@dataclass
+class MapImage:
+    """A rendered vacuum map."""
+
+    image: bytes  # PNG
+    width: int
+    height: int
+    calibration_points: list[dict] = field(default_factory=list)
+
+
+def _rotate(point, radians):
+    return (
+        math.cos(radians) * point[0] - math.sin(radians) * point[1],
+        math.sin(radians) * point[0] + math.cos(radians) * point[1],
+    )
+
+
+def _to_global(point, transform):
+    """Map a local-frame point to the persistent map frame."""
+    tx, ty, a = transform
+    return _rotate((point[0] - tx, point[1] - ty), -a)
+
+
+def render_map(reported: dict, rotation_deg: float = 0.0, robot_marker: str = ROBOT_MARKER_NONE) -> MapImage | None:
+    """Render the vacuum map from the reported appliance state.
+
+    robot_marker selects where the robot is drawn: at its reported pose (only
+    meaningful while the robot is moving), on the charger (when docked), or
+    not at all. Returns None when the state carries no usable map data.
+    """
+    map_data = reported.get("mapData")
+    if not map_data or not map_data.get("crumbs"):
+        return None
+
+    view_rotation = math.radians(rotation_deg)
+
+    def view(point):
+        return _rotate(point, view_rotation)
+
+    transforms = {t["t"]: t["xya"] for t in map_data.get("transforms", []) if len(t.get("xya", [])) == 3}
+    identity = [0.0, 0.0, 0.0]
+
+    # Crumb chunks, each in its own frame; keep chunks separate so the pen
+    # lifts between them instead of drawing a stroke across the room.
+    chunks: list[tuple[int, list]] = []
+    for crumb in map_data["crumbs"]:
+        if "xy" not in crumb:
+            continue
+        pos = view(_to_global(crumb["xy"], transforms.get(crumb.get("t"), identity)))
+        if chunks and chunks[-1][0] == crumb.get("t"):
+            chunks[-1][1].append(pos)
+        else:
+            chunks.append((crumb.get("t"), [pos]))
+    if not chunks:
+        return None
+
+    # The charger is the origin of local frame 0: the robot zeroes its
+    # odometry on the dock at session start (verified: transform 0 is always
+    # exactly the inverse of the charger pose). The reported chargerPoses is
+    # not reliable - it flip-flops between global coordinates and the local
+    # frame-0 origin (0, 0, 0) across sessions - so it is only a fallback.
+    charger = charger_heading = None
+    if 0 in transforms:
+        charger = view(_to_global((0.0, 0.0), transforms[0]))
+        charger_heading = -transforms[0][2] + view_rotation
+    else:
+        charger_poses = map_data.get("chargerPoses")
+        if charger_poses and len(charger_poses[0].get("xya", [])) >= 2:
+            xya = charger_poses[0]["xya"]
+            charger = view(xya[:2])
+            charger_heading = (xya[2] if len(xya) == 3 else 0.0) + view_rotation
+
+    # The robot pose is reported directly in the global frame (verified: it
+    # coincides with the last reported crumb; the identity transform tagged
+    # t=1000 is its frame marker). It is only current while the robot is
+    # moving - when docked the pose is a stale mid-session snapshot, so the
+    # robot is drawn on the charger instead.
+    robot = robot_heading = None
+    robot_pose = map_data.get("robotPose")
+    if robot_marker == ROBOT_MARKER_POSE and robot_pose and len(robot_pose.get("xya", [])) == 3:
+        robot = view(robot_pose["xya"][:2])
+        robot_heading = robot_pose["xya"][2] + view_rotation
+    elif robot_marker == ROBOT_MARKER_CHARGER and charger:
+        robot = charger
+        robot_heading = charger_heading
+
+    points = [p for _, chunk in chunks for p in chunk]
+    if charger:
+        points.append(charger)
+    if robot:
+        points.append(robot)
+
+    xs, ys = [p[0] for p in points], [p[1] for p in points]
+    xmin, xmax = min(xs) - PADDING_M, max(xs) + PADDING_M
+    ymin, ymax = min(ys) - PADDING_M, max(ys) + PADDING_M
+
+    scale = SCALE * SUPERSAMPLE
+    width = min(int((xmax - xmin) * scale), MAX_DIMENSION_PX * SUPERSAMPLE)
+    height = min(int((ymax - ymin) * scale), MAX_DIMENSION_PX * SUPERSAMPLE)
+    if width < 1 or height < 1:
+        return None
+
+    def px(point):
+        # y axis flipped: world y up, image y down
+        return ((point[0] - xmin) * scale, (ymax - point[1]) * scale)
+
+    img = Image.new("RGBA", (width, height), BACKGROUND)
+    draw = ImageDraw.Draw(img)
+
+    # Coverage swath: a stroke as wide as the robot along the crumb path
+    swath_width = int(ROBOT_WIDTH_M * scale)
+    for _, chunk in chunks:
+        for run in _split_runs(chunk):
+            pts = [px(p) for p in run]
+            if len(pts) > 1:
+                draw.line(pts, fill=SWATH, width=swath_width, joint="curve")
+            for p in (pts[0], pts[-1]):
+                radius = swath_width / 2
+                draw.ellipse([p[0] - radius, p[1] - radius, p[0] + radius, p[1] + radius], fill=SWATH)
+
+    # Centre path line on top of the swath
+    for _, chunk in chunks:
+        for run in _split_runs(chunk):
+            pts = [px(p) for p in run]
+            if len(pts) > 1:
+                draw.line(pts, fill=PATH, width=max(2, scale // 40), joint="curve")
+
+    if charger:
+        _draw_charger(draw, px(charger), scale)
+    if robot:
+        _draw_robot(draw, px, robot, robot_heading, scale)
+
+    img = img.resize((width // SUPERSAMPLE, height // SUPERSAMPLE), Image.LANCZOS)
+    buffer = io.BytesIO()
+    img.convert("RGB").save(buffer, "PNG")
+
+    # Three reference points mapping the vacuum (global metres) frame to
+    # image pixels, in the attribute format established by
+    # mqtt_vacuum_camera / xiaomi-vacuum-map-card.
+    def calibration_point(px_x: int, px_y: int) -> dict:
+        rotated = (xmin + px_x * SUPERSAMPLE / scale, ymax - px_y * SUPERSAMPLE / scale)
+        world = _rotate(rotated, -view_rotation)
+        return {
+            "vacuum": {"x": round(world[0], 3), "y": round(world[1], 3)},
+            "map": {"x": px_x, "y": px_y},
+        }
+
+    out_width, out_height = img.width, img.height
+    calibration_points = [
+        calibration_point(0, 0),
+        calibration_point(out_width, 0),
+        calibration_point(0, out_height),
+    ]
+
+    return MapImage(
+        image=buffer.getvalue(),
+        width=out_width,
+        height=out_height,
+        calibration_points=calibration_points,
+    )
+
+
+def _split_runs(chunk):
+    """Split a crumb chunk where consecutive points are implausibly far apart."""
+    runs, run = [], [chunk[0]]
+    for prev, cur in zip(chunk, chunk[1:]):
+        if math.dist(prev, cur) > MAX_SEGMENT_M:
+            runs.append(run)
+            run = [cur]
+        else:
+            run.append(cur)
+    runs.append(run)
+    return runs
+
+
+def _draw_charger(draw, center, scale):
+    cx, cy = center
+    radius = 0.14 * scale
+    draw.ellipse([cx - radius, cy - radius, cx + radius, cy + radius], fill=CHARGER)
+    draw.line([cx, cy - radius * 0.5, cx, cy + radius * 0.5], fill=BACKGROUND, width=int(radius / 3))
+    draw.line([cx - radius * 0.4, cy, cx + radius * 0.4, cy], fill=BACKGROUND, width=int(radius / 3))
+
+
+def _draw_robot(draw, px, robot, heading, scale):
+    """Draw the robot marker: body, front chord, lidar dot and button dot."""
+    rx, ry = px(robot)
+    radius_m = ROBOT_WIDTH_M / 2
+    radius = radius_m * scale
+    line_width = max(2, int(radius / 11))
+
+    def along(dist_m, angle):
+        return px((robot[0] + dist_m * math.cos(angle), robot[1] + dist_m * math.sin(angle)))
+
+    draw.ellipse(
+        [rx - radius, ry - radius, rx + radius, ry + radius],
+        fill=ROBOT_FILL,
+        outline=ROBOT_OUTLINE,
+        width=line_width,
+    )
+    chord = [
+        along(radius_m * 0.9, heading - math.radians(80)),
+        along(radius_m * 0.9, heading + math.radians(80)),
+    ]
+    draw.line(chord, fill=ROBOT_OUTLINE, width=line_width)
+    lidar_x, lidar_y = along(radius_m * 0.6, heading)
+    lidar_r = radius * 3 / 11
+    draw.ellipse([lidar_x - lidar_r, lidar_y - lidar_r, lidar_x + lidar_r, lidar_y + lidar_r], fill=ROBOT_OUTLINE)
+    button_x, button_y = along(radius_m * 0.8, heading + math.pi)
+    button_r = radius * 1.5 / 11
+    draw.ellipse(
+        [button_x - button_r, button_y - button_r, button_x + button_r, button_y + button_r], fill=ROBOT_OUTLINE
+    )

--- a/custom_components/wellbeing/translations/en.json
+++ b/custom_components/wellbeing/translations/en.json
@@ -37,7 +37,8 @@
           "binary_sensor": "Binary sensor activated",
           "sensor": "Sensor activated",
           "switch": "Switch activated",
-          "stream": "Use Live Stream API instead of polling"
+          "stream": "Use Live Stream API instead of polling",
+          "map_rotation": "Vacuum map rotation (degrees counter-clockwise)"
         }
       }
     }


### PR DESCRIPTION
# Add a map camera entity for robot vacuums

Closes #184

## What

Adds a `camera` platform that renders the robot vacuum's map from the dynamic
map data (`mapData`) the Electrolux API reports in the appliance state:

- the covered area (a swath as wide as the robot along the reported "crumbs"),
- the cleaning path,
- the charger position,
- the robot position and heading — at its reported pose while moving, parked
  on the charger while docked or sleeping (when not moving the reported pose
  is a stale mid-session snapshot, so it is never used then). The pose marker
  is also suppressed while the reported map still belongs to the *previous*
  session — see the latency note below.

<img width="551" height="688" alt="snapshot_camera_moriarty_map_12_07_2026, 21_17_15" src="https://github.com/user-attachments/assets/771b89d9-2d35-4291-9369-7df7f140c8a1" />

### Limitation
During development, it was found that the API is very slow in updating map data. It seems that there is a number of minutes (~6 minutes) before the first map data arrives after starting a new cleaning session, and subsequent uploads come a few minutes apart. 
This is much slower than what the native Electrolux app achieves unfortunately. Hence, this map rendering shall be seen as a way to see *what the robot did*, rather than *what the robot is doing*.

 

## Notes on the map data

As noted in #184, the API now reports crumbs/poses/transforms but no image.
Rendering them requires knowing the coordinate convention, which I reverse
engineered and verified on a PUREi9.2:

- Crumbs are recorded in per-chunk local frames; each crumb's `t` selects a
  transform `(tx, ty, a)` from `mapData.transforms`, and
  `global = R(-a) @ (p - (tx, ty))`.
- Verification: local frame 0's origin maps exactly onto the reported
  `chargerPoses[0]` (the robot starts each session on the charger), and the
  transformed crumb trail is continuous.
- The robot pose is already in the global (persistent map) frame — verified
  live: it coincides with the last reported crumb (within ~1 cm).
- The charger is the origin of local frame 0: the robot zeroes its odometry
  on the dock, so transform 0 is always exactly the inverse of the charger
  pose. The renderer derives the charger from transform 0, because the
  reported `chargerPoses` is unreliable — observed flip-flopping between
  global coordinates and the frame-0-local origin `(0, 0, 0)` across
  sessions on the same robot.
- The state carries a `crumbCollectionDelta` flag. Observed once (coinciding
  with a live map view being open in the Electrolux app, though causation is
  unproven): the flag turned `true` and the crumbs array stopped carrying
  the full trail - consistent with delta uploads of only-new crumbs, and
  with the map appearing to "reset" in a naive renderer. The camera
  therefore accumulates crumbs per session while the flag is set and
  replaces the trail on full (non-delta) uploads. Both observed
  session-final uploads were full lists, so the final map self-corrects;
  and if the delta interpretation is subtly wrong, accumulation degrades to
  harmless duplicate points rather than a broken map.

## Card compatibility

The camera exposes a `calibration_points` attribute in the format established
by mqtt_vacuum_camera, mapping the vacuum coordinate frame (metres) to image
pixels. This makes it a drop-in `map_source` for
[xiaomi-vacuum-map-card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card)
with `calibration_source: camera: true`:

```yaml
type: custom:xiaomi-vacuum-map-card
entity: vacuum.your_robot
vacuum_platform: default
map_source:
  camera: camera.your_robot_map
calibration_source:
  camera: true
```

## Fix: polling starvation with the Live Stream API enabled

While testing I found that with the live stream option enabled, the map (and
any other property that only arrives via polling) froze during cleaning
sessions. Root cause: `_listen_for_changes` called
`coordinator.async_set_updated_data` on every stream event, and that method
*resets the coordinator's refresh interval*. A steady trickle of stream events
(battery/status updates while cleaning or charging) therefore postponed the
poll indefinitely. The stream only carries `batteryStatus`, `powerMode`,
`robotStatus` and `connectionState`, so everything else went stale.

Fixed by notifying listeners with `async_update_listeners()` instead, which
leaves the polling schedule untouched. This also benefits existing entities
(e.g. dustbin status) independently of the camera.

## Implementation

- `map_renderer.py` — pure, synchronous rendering module (Pillow), executed in
  an executor job. Returns PNG bytes + calibration points. Handles missing or
  malformed map data by returning `None`.
- `camera.py` — `WellbeingCamera(WellbeingEntity, Camera)`, created for any
  appliance whose reported state contains `mapData` (gated the same way as all
  other entities, via `attr in data`). Renders lazily and caches on a
  `(timestamp, sessionId, crumb count, robot-active)` key, so unchanged data is
  never re-rendered.
- A new integration option "Vacuum map rotation (degrees counter-clockwise)"
  rotates the rendered map, e.g. to match the orientation shown in the
  Electrolux app. Default 0.
- New requirement `Pillow>=10.1.0` (already bundled with Home Assistant, so in
  practice nothing new is installed).

## Tested

- PUREi9 (firmware 43.23), Home Assistant 2026.7.1, live stream option
  enabled: camera entity appears, renders the last/current session, updates
  live while cleaning (after the polling fix above), the robot marker follows
  the robot and parks on the charger when docked, and the camera works in
  xiaomi-vacuum-map-card with camera calibration.
- Graceful behaviour verified with empty/missing `mapData`.
Not tested:
- I don't own a 700-series robot; if its state reports `mapData` in the same
  shape it should work, otherwise no camera entity is created. Happy to adjust
  based on feedback from 700-series owners.
- Segments/zones.

## Follow-up ideas (not in this PR)

- Draw interactive-map zones (names/outlines) on the map; needs the zone
  vertex format from the interactiveMap endpoint, which requires extra API
  calls and verification.
- Cleaning session and consumable sensors — already implemented and tested,
  coming as a separate follow-up PR to keep this one focused on the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)