### PR TITLE
Add cleaning session and consumable sensors for robot vacuums

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -36,6 +36,13 @@ in the Electrolux app.
 
 ### PUREi9
 
+Consumable sensors (Main Brush, Side Brush, Filter) show remaining life in
+percent. The API only reports usage in square metres since the last reset;
+the rated lifetimes (3000 m² for the main brush, 1000 m² for the side brush
+and the filter) are not exposed by the API and were reverse engineered from
+the percentages shown in the Electrolux app. Counters can only be reset from
+the app.
+
 The PUREi9.2 RVC supports the action `vacuum.send_command` with the command `clean_zones`, which allows for zone cleaning. The command expects two parameters: `map`, which is the name of a map (as named in the Wellbeing app), and `zones`, which is a list of zones to be cleaned. A zone in the list can either be the name of a zone to be cleaned (as a single string) or a dictionary containing the required key `zone` and an optional key `fan_speed` with values `power`, `quiet`, or `smart` to be used for the zone. If `fan_speed` is not specified, the default fan speed specified for that zone will be used.
 
 #### Example 1

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -9,11 +9,17 @@ This text contains manual entries for non-obvious features of specific appliance
 Robot vacuums whose appliance state reports dynamic map data (verified on the
 PUREi9.2) get a camera entity showing the map of the latest cleaning session:
 the covered area, the cleaning path, the charger and — while the robot is
-moving — the robot itself. The image updates on every API update, so it shows
-live progress during a cleaning session.
+moving — the robot itself. The image updates on every API update. Please note
+that Electrolux's API provides the map data with quite a few minutes of delay,
+i.e. much slower than the native Electrolux app. So consider it a map of what
+the robot has cleaned, rather than where the robot is right now.
 
 The camera can be used with a plain picture-entity card, or with
-[xiaomi-vacuum-map-card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card):
+[Xiaomi Vacuum Map Card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card),
+which can be installed from [HACS](https://hacs.xyz) (search for "Xiaomi
+Vacuum Map Card"). An example configuration, with tiles for status, battery,
+fan speed, cleaned area and cleaning time (the latter two are only available
+on appliances that report cleaning session data):
 
 ```yaml
 type: custom:xiaomi-vacuum-map-card
@@ -23,6 +29,29 @@ map_source:
   camera: camera.your_robot_map
 calibration_source:
   camera: true
+map_locked: true
+tiles:
+  - label: Status
+    entity: vacuum.your_robot
+    icon: mdi:robot-vacuum
+  - label: Battery
+    entity: sensor.your_robot_battery
+    icon: mdi:battery
+    unit: "%"
+  - label: Fan speed
+    entity: vacuum.your_robot
+    attribute: fan_speed
+    icon: mdi:fan
+  - label: Cleaned area
+    entity: sensor.your_robot_cleaned_area
+    icon: mdi:texture-box
+    unit: m²
+  - label: Cleaning time
+    entity: sensor.your_robot_cleaning_time
+    icon: mdi:timer-outline
+    unit: min
+    multiplier: 0.01666667
+    precision: 0
 ```
 
 The camera exposes a `calibration_points` attribute mapping the vacuum

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -8,7 +8,9 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.const import (
+    UnitOfArea,
     UnitOfTemperature,
+    UnitOfTime,
     PERCENTAGE,
     CONCENTRATION_PARTS_PER_MILLION,
     CONCENTRATION_PARTS_PER_BILLION,
@@ -137,6 +139,9 @@ class ApplianceEntity:
         state_class: SensorStateClass | str | None = None,
     ) -> None:
         self.attr = attr
+        # The state attribute the entity reads; attr stays the unique
+        # identity even when several entities share one source attribute.
+        self.source_attr = attr
         self.name = name
         self.device_class = device_class
         self.entity_category = entity_category
@@ -144,7 +149,7 @@ class ApplianceEntity:
         self._state = None
 
     def setup(self, data):
-        self._state = data[self.attr]
+        self._state = data[self.source_attr]
         return self
 
     def clear_state(self):
@@ -218,6 +223,56 @@ class ApplianceCamera(ApplianceEntity):
 
     def __init__(self, name, attr) -> None:
         super().__init__(name, attr)
+
+
+class ApplianceConsumableSensor(ApplianceSensor):
+    """Remaining life of a consumable, in percent.
+
+    The API reports usage in square metres since the consumable was last
+    reset; the rated lifetimes are not exposed, so they are hard coded per
+    model (reverse engineered from the percentages shown in the Electrolux
+    app for a PUREi9.2).
+    """
+
+    def __init__(self, name, attr, rated_sqm) -> None:
+        super().__init__(
+            name,
+            attr,
+            unit=PERCENTAGE,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            state_class=SensorStateClass.MEASUREMENT,
+        )
+        self.rated_sqm = rated_sqm
+
+    def setup(self, data):
+        self._state = max(0, round(100 * (1 - float(data[self.source_attr]) / self.rated_sqm)))
+        return self
+
+
+class ApplianceCleaningSessionSensor(ApplianceSensor):
+    """Sensor reading one value from the vacuum's reported cleaningSession."""
+
+    def __init__(
+        self,
+        name,
+        attr,
+        session_key,
+        unit="",
+        device_class=None,
+        state_class: SensorStateClass | str | None = None,
+        transform=None,
+    ) -> None:
+        super().__init__(name, attr, unit, device_class, state_class=state_class)
+        self.source_attr = "cleaningSession"
+        self.session_key = session_key
+        self.transform = transform
+
+    def setup(self, data):
+        value = (data.get(self.source_attr) or {}).get(self.session_key)
+        if value is not None and self.transform is not None:
+            value = self.transform(value)
+        self._state = value
+        return self
 
 
 class Appliance:
@@ -397,6 +452,26 @@ class Appliance:
                 name="Map",
                 attr="mapData",
             ),
+            # Only created for robots whose state reports cleaningSession
+            ApplianceCleaningSessionSensor(
+                name="Cleaned Area",
+                attr="cleanedArea",
+                session_key="areaCovered",
+                unit=UnitOfArea.SQUARE_METERS,
+                device_class=SensorDeviceClass.AREA,
+                state_class=SensorStateClass.MEASUREMENT,
+                transform=lambda value: round(float(value), 1),
+            ),
+            ApplianceCleaningSessionSensor(
+                name="Cleaning Time",
+                attr="cleaningTime",
+                session_key="cleaningDuration",
+                unit=UnitOfTime.SECONDS,
+                device_class=SensorDeviceClass.DURATION,
+                state_class=SensorStateClass.MEASUREMENT,
+                # cleaningDuration is reported in 100 ns ticks
+                transform=lambda value: round(int(value) / 1e7),
+            ),
         ]
 
         vacuum_purei9_entities = [
@@ -413,6 +488,21 @@ class Appliance:
                 name="Robot Status",
                 attr="robotStatus",
                 device_class=SensorDeviceClass.ENUM,
+            ),
+            ApplianceConsumableSensor(
+                name="Main Brush",
+                attr="main_brush_sqm",
+                rated_sqm=3000,
+            ),
+            ApplianceConsumableSensor(
+                name="Side Brush",
+                attr="side_brush_sqm",
+                rated_sqm=1000,
+            ),
+            ApplianceConsumableSensor(
+                name="Filter",
+                attr="filter_sqm",
+                rated_sqm=1000,
             ),
         ]
 
@@ -622,7 +712,7 @@ class Appliance:
         self.entities = [
             entity.setup(data)
             for entity in Appliance._create_entities(data)
-            if entity.attr in data
+            if entity.source_attr in data
         ]
 
     @property


### PR DESCRIPTION
# Add cleaning session and consumable sensors for robot vacuums

Follow-up to the map camera PR (#233), split out to keep that one focused.

Note: this branch is based on `main` and is independent of #233, but both add
entries to adjacent lines in `api.py`, so whichever is merged second will need
a trivial rebase — happy to do that once #233 lands (or vice versa).

## Cleaning session sensors

Two sensors per robot, read from the `cleaningSession` dict in the reported
state (created only when the appliance reports it):

- **Cleaned Area** (m²) — `areaCovered`
- **Cleaning Time** (seconds, `duration` device class) — `cleaningDuration`,
  which the API reports in 100 ns ticks (verified against a wall clock on a
  PUREi9.2: a 14 min 40 s session reported 8 800 000 000 ticks)

Both update while a session is running, so they show live progress.

## Consumable sensors (PUREi9)

**Main Brush**, **Side Brush** and **Filter**, showing remaining life in
percent as diagnostic sensors — matching what the Electrolux app displays.

The API only reports usage in square metres since each consumable was last
reset (`main_brush_sqm`, `side_brush_sqm`, `filter_sqm`); the rated lifetimes
are not exposed anywhere in the API, so they are hard coded per model and were
reverse engineered from the app: with equal usage counters (55.84 m²) the app
showed 98 % main brush and 94 % side brush/filter, giving rated lifetimes of
3000 m² (main brush) and 1000 m² (side brush, filter) as the only round values
consistent with the displayed percentages under both rounding and flooring.
Verified to track the app across multiple cleaning sessions. Counters can only
be reset from the Electrolux app; the sensors follow the reset automatically
since they are computed from the reported counters.

## Implementation

`ApplianceEntity` gains a `source_attr` (defaulting to `attr`) so several
entities can read different values from one state attribute while keeping
unique identities — `attr` remains the unique id/entity-id component, while
`source_attr` selects the reported state key and gates entity creation.

## Tested

PUREi9 (firmware 43.23), Home Assistant 2026.7.1: all five sensors created
with correct values, live updates during cleaning sessions verified. The
700-series reports consumables as percentages via different attributes
(`mainBrushUsage` etc.), which this PR does not cover — the sqm-based sensors
are simply not created for appliances that do not report the sqm counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)