### PR TITLE
fix: prevent reload storms and unnecessary livestream requests

### DIFF
--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -54,7 +54,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # refreshes - but the stream does not carry every property (e.g. the
     # vacuum map data only arrives via polling), so while a vacuum is active
     # the coordinator polls at the base interval to follow the cleaning session.
-    if entry.options.get(CONF_STREAM, DEFAULT_STREAM):
+    use_stream = entry.options.get(CONF_STREAM, DEFAULT_STREAM)
+    if use_stream:
         update_interval = timedelta(seconds=base_interval * 5)
     else:
         update_interval = timedelta(seconds=base_interval)
@@ -68,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except Exception as exception:
         raise ConfigEntryAuthFailed("Failed to setup API") from exception
 
-    client = WellbeingApiClient(hub)
+    client = WellbeingApiClient(hub, use_stream=use_stream)
 
     coordinator = WellbeingDataUpdateCoordinator(
         hass,
@@ -79,7 +80,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await coordinator.async_config_entry_first_refresh()
 
-    if entry.options.get(CONF_STREAM, DEFAULT_STREAM):
+    if use_stream:
         entry.async_create_background_task(
             hass, coordinator._listen_for_changes(), "wellbeing_stream"
         )
@@ -91,7 +92,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.add_update_listener(async_reload_entry)
     return True
 
 
@@ -102,11 +102,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the config entry when it changed."""
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 class WellbeingDataUpdateCoordinator(DataUpdateCoordinator):
@@ -143,9 +138,15 @@ class WellbeingDataUpdateCoordinator(DataUpdateCoordinator):
         """Whether any robot vacuum is currently on a cleaning session."""
         from homeassistant.components.vacuum import VacuumActivity
 
-        from .vacuum import VACUUM_ACTIVITIES  # local import, vacuum.py imports this module
+        from .vacuum import (
+            VACUUM_ACTIVITIES,
+        )  # local import, vacuum.py imports this module
 
-        active = {VacuumActivity.CLEANING, VacuumActivity.RETURNING, VacuumActivity.PAUSED}
+        active = {
+            VacuumActivity.CLEANING,
+            VacuumActivity.RETURNING,
+            VacuumActivity.PAUSED,
+        }
         return any(
             VACUUM_ACTIVITIES.get(entity.state) in active
             for appliance in appliances.appliances.values()
@@ -190,14 +191,14 @@ class WellBeingTokenManager(TokenManager):
         _LOGGER.debug(f"Access token: {self._mask_access_token(access_token)}")
         _LOGGER.debug(f"Refresh token: {self._mask_access_token(refresh_token)}")
 
-        self._hass.config_entries.async_update_entry(
-            self._entry,
-            data={
-                CONF_API_KEY: self.api_key,
-                CONF_REFRESH_TOKEN: refresh_token,
-                CONF_ACCESS_TOKEN: access_token,
-            },
-        )
+        data = {
+            **self._entry.data,
+            CONF_API_KEY: self.api_key,
+            CONF_REFRESH_TOKEN: refresh_token,
+            CONF_ACCESS_TOKEN: access_token,
+        }
+        if data != self._entry.data:
+            self._hass.config_entries.async_update_entry(self._entry, data=data)
 
     @staticmethod
     def _mask_access_token(token: str):

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -245,7 +245,9 @@ class ApplianceConsumableSensor(ApplianceSensor):
         self.rated_sqm = rated_sqm
 
     def setup(self, data):
-        self._state = max(0, round(100 * (1 - float(data[self.source_attr]) / self.rated_sqm)))
+        self._state = max(
+            0, round(100 * (1 - float(data[self.source_attr]) / self.rated_sqm))
+        )
         return self
 
 
@@ -852,11 +854,12 @@ class Appliances:
 
 
 class WellbeingApiClient:
-    def __init__(self, hub: ElectroluxHubAPI) -> None:
+    def __init__(self, hub: ElectroluxHubAPI, *, use_stream: bool) -> None:
         """Sample API Client."""
         self._api_appliances: dict[str, ApiAppliance] = {}
         self._hub = hub
         self._load_lock = asyncio.Lock()
+        self._use_stream = use_stream
         self._livestream_properties: dict[str, list[str]] = {}
 
     async def _ensure_loaded(self) -> None:
@@ -868,20 +871,21 @@ class WellbeingApiClient:
             appliances: list[ApiAppliance] = await self._hub.async_get_appliances()
             self._api_appliances = {appliance.id: appliance for appliance in appliances}
 
-            try:
-                livestream_configs = (
-                    await self._hub.async_get_livestream_configurations()
-                )
-                for appliance_config in livestream_configs.get("appliances", []):
-                    appliance_id = appliance_config.get("applianceId")
-                    properties = appliance_config.get("properties", [])
-                    if appliance_id and properties:
-                        self._livestream_properties[appliance_id] = properties
-                        _LOGGER.debug(
-                            f"Appliance {appliance_id} supports livestreaming for properties: {properties}"
-                        )
-            except Exception as e:
-                _LOGGER.warning(f"Failed to fetch livestream configurations: {e}")
+            if self._use_stream:
+                try:
+                    livestream_configs = (
+                        await self._hub.async_get_livestream_configurations()
+                    )
+                    for appliance_config in livestream_configs.get("appliances", []):
+                        appliance_id = appliance_config.get("applianceId")
+                        properties = appliance_config.get("properties", [])
+                        if appliance_id and properties:
+                            self._livestream_properties[appliance_id] = properties
+                            _LOGGER.debug(
+                                f"Appliance {appliance_id} supports livestreaming for properties: {properties}"
+                            )
+                except Exception as e:
+                    _LOGGER.warning(f"Failed to fetch livestream configurations: {e}")
 
     def update_appliance_state(self, ha_appliances, appliance_id, property_name, value):
         appliance = self._api_appliances.get(appliance_id)

--- a/custom_components/wellbeing/config_flow.py
+++ b/custom_components/wellbeing/config_flow.py
@@ -168,11 +168,8 @@ class WellBeingConfigFlowTokenManager(TokenManager):
         super().update(access_token, refresh_token, api_key)
 
 
-class WellbeingOptionsFlowHandler(config_entries.OptionsFlow):
+class WellbeingOptionsFlowHandler(config_entries.OptionsFlowWithReload):
     """Config flow options handler for wellbeing."""
-
-    def __init__(self):
-        """Initialize HACS options flow."""
 
     async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument
         """Manage the options."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp
 homeassistant==2026.1.0
-pyelectroluxgroup==0.2.6
+pyelectroluxgroup==0.2.7


### PR DESCRIPTION
This fixes repeated config-entry reloads that can make all Wellbeing entities alternate between unavailable and their restored state. It also stops polling setups from calling the livestream configuration endpoint.

## Root cause

The integration registered a reload listener on every setup without removing it during unload. Token initialization and refresh both call `async_update_entry`, so stale listeners could accumulate and turn one token update into a cascade of config-entry reloads.

`WellbeingApiClient._ensure_loaded` also requested `/configurations/livestream` unconditionally, including when the livestream option was disabled. This generated unnecessary requests and could trigger HTTP 429 responses.

## Impact

Token refreshes no longer reload the integration or repeatedly make all entities unavailable. Options changes still trigger one intentional reload through Home Assistant's options-flow helper, while reauthentication keeps its explicit reload behavior. Polling users no longer call the livestream configuration endpoint.

Checked locally against Home Assistant 2026.7.2 with focused coverage of polling, livestream configuration handling, and token persistence.
