### PR TITLE
fix: accept Azul appliance model casing

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -108,7 +108,7 @@ class Model(str, Enum):
     VacuumHygienic700 = "Gordias"  # HYGIENIC700
     Cybele = "Cybele"
     COMFORT600 = "COMFORT600"
-    AZUL = "AZUL"
+    AZUL = "Azul"
 
 
 class WorkMode(str, Enum):


### PR DESCRIPTION
## Root cause

Electrolux reports AEG Comfort 6000 units with the appliance type `Azul`, while the integration only accepts `AZUL`. The [official Electrolux Group Developer SDK](https://github.com/electrolux-oss/electrolux-group-developer-sdk/blob/main/electrolux_group_developer_sdk/constants.py) defines this mapping as `AZUL = "Azul"` and uses that value to dispatch `appliance.applianceType` to the air-conditioner implementation. Model construction therefore fails with a `ValueError` before the climate entity can be created.

## Impact

Matching the API value used by Electrolux lets affected AEG Comfort 6000 units finish setup and expose their climate entity.

Closes #222
