### PR TITLE
fix: preserve discrete fan speed levels

### DIFF
--- a/custom_components/wellbeing/fan.py
+++ b/custom_components/wellbeing/fan.py
@@ -83,7 +83,7 @@ class WellbeingFan(WellbeingEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
-        self._speed = math.floor(
+        self._speed = math.ceil(
             percentage_to_ranged_value(self._speed_range, percentage)
         )
         self.get_entity.clear_state()
@@ -151,7 +151,7 @@ class WellbeingFan(WellbeingEntity, FanEntity):
                 return
 
         # Proceed with the provided or default percentage
-        self._speed = math.floor(
+        self._speed = math.ceil(
             percentage_to_ranged_value(self._speed_range, percentage or 10)
         )
         self.get_appliance.set_mode(self._preset_mode)


### PR DESCRIPTION
## Root cause

Fan speed percentages were converted to appliance levels with `math.floor()`. Home Assistant's percentage helper can return a value just below an integer for a valid discrete step—for example, 11% maps to 0.99 for a 1–9 range—so flooring shifts the requested level down and can send the invalid `Fanspeed: 0` command.

## Impact

Using `math.ceil()` preserves every supported discrete level when changing the percentage or turning the fan on. This follows [Home Assistant's documented conversion for numeric fan-speed ranges](https://developers.home-assistant.io/docs/core/entity/fan/#converting-speeds) and works for both the 1–5 and 1–9 ranges used by the integration.
