### PR TITLE
fix: sync entity state from coordinator

### DIFF
--- a/custom_components/wellbeing/fan.py
+++ b/custom_components/wellbeing/fan.py
@@ -71,7 +71,7 @@ class WellbeingFan(WellbeingEntity, FanEntity):
     @property
     def percentage(self):
         """Return the current speed percentage."""
-        if self._preset_mode == WorkMode.OFF:
+        if self.preset_mode == WorkMode.OFF:
             speed = 0
         else:
             speed = (

--- a/custom_components/wellbeing/switch.py
+++ b/custom_components/wellbeing/switch.py
@@ -30,23 +30,18 @@ class WellbeingSwitch(WellbeingEntity, SwitchEntity):
     def __init__(self, coordinator, config_entry, pnc_id, function):
         super().__init__(coordinator, config_entry, pnc_id, "binary_sensor", function)
         self._function = function
-        self._is_on = self.get_entity.state
 
     @property
     def is_on(self):
         """Return true if switch is on."""
-        return self._is_on
+        return self.get_entity.state
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         await self.coordinator.api.set_feature_state(self.pnc_id, self._function, True)
-        self._is_on = True
-        self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         await self.coordinator.api.set_feature_state(self.pnc_id, self._function, False)
-        self._is_on = False
-        self.async_write_ha_state()
         await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Root cause

The UI light, ionizer, and safety lock switches cached their state when the entity was created. Coordinator refreshes replace the appliance data, but never updated that private cache, so changes made in the Electrolux app or received from a later API update were not reflected by the switch. The fan percentage had the same issue for its off check: it consulted the preset captured at startup instead of the latest coordinator-backed mode.

## Impact

Switch and fan state now comes from the latest coordinator data, following [Home Assistant's entity update model](https://developers.home-assistant.io/docs/core/entity/#subscribing-to-updates). Switch commands still request an immediate coordinator refresh after the API call, while external changes are reflected on the next poll or livestream event.
