### PR TITLE
fix: respect air purifier fan capabilities

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -732,11 +732,15 @@ class Appliance:
 
     @property
     def speed_range(self) -> tuple[int, int]:
+        fan_speed = self.capabilities.get("Fanspeed", {})
+        minimum = fan_speed.get("min")
+        maximum = fan_speed.get("max")
+        if isinstance(minimum, int) and isinstance(maximum, int) and minimum <= maximum:
+            return minimum, maximum
+
         ## Electrolux Devices:
         if self.model == Model.Muju:
-            if self.mode is WorkMode.QUITE:
-                return 1, 2
-            return 1, 5
+            return 1, 3
         if self.model == Model.WELLA5:
             return 1, 5
         if self.model == Model.WELLA7:

--- a/custom_components/wellbeing/fan.py
+++ b/custom_components/wellbeing/fan.py
@@ -140,7 +140,11 @@ class WellbeingFan(WellbeingEntity, FanEntity):
     async def async_turn_on(
         self, percentage: int | None = None, preset_mode: str | None = None, **kwargs
     ) -> None:
-        self._preset_mode = self.get_appliance.work_mode_from_preset_mode(preset_mode)
+        self._preset_mode = (
+            WorkMode.MANUAL
+            if percentage is not None
+            else self.get_appliance.work_mode_from_preset_mode(preset_mode)
+        )
 
         # Handle incorrect percentage
         if percentage is not None and isinstance(percentage, str):
@@ -159,7 +163,7 @@ class WellbeingFan(WellbeingEntity, FanEntity):
 
         await self.api.set_work_mode(self.pnc_id, self._preset_mode)
 
-        if self._preset_mode != WorkMode.AUTO:
+        if self._preset_mode == WorkMode.MANUAL:
             await self.api.set_fan_speed(self.pnc_id, self._speed)
 
         await asyncio.sleep(10)


### PR DESCRIPTION
## Root cause

Fan speed ranges were hardcoded by appliance type. Pure 500 / Muju devices report a 1–3 range in their `Fanspeed` capability, but the integration exposed 1–5. Turning a Muju fan on also sent a `Fanspeed` command after selecting Smart or Quiet, even though both modes mark that capability as disabled. The [official Electrolux SDK](https://github.com/electrolux-oss/electrolux-group-developer-sdk/blob/v0.6.0/electrolux_group_developer_sdk/appliance_config/ap_config.py) reads the range from capabilities, and the payload attached to #120 reports the same 1–3 range and mode restrictions.

## Impact

The integration now uses the range advertised by each purifier, with the existing model table retained as a fallback. Pure 500 exposes three manual levels and no longer sends a disabled speed command when Smart or Quiet is selected. Supplying a percentage explicitly selects Manual before sending the speed, matching [Home Assistant's fan entity contract](https://developers.home-assistant.io/docs/core/entity/fan/#preset-modes).

Addresses #120 and #171
