### PR TITLE
fix: reconcile polling and livestream updates

### DIFF
--- a/custom_components/wellbeing/__init__.py
+++ b/custom_components/wellbeing/__init__.py
@@ -70,7 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except Exception as exception:
         raise ConfigEntryAuthFailed("Failed to setup API") from exception
 
-    client = WellbeingApiClient(hub, use_stream=use_stream)
+    client = WellbeingApiClient(hub)
 
     coordinator = WellbeingDataUpdateCoordinator(
         hass,

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -1,7 +1,6 @@
 """Sample API Client."""
 
 import asyncio
-import copy
 import logging
 from enum import StrEnum
 
@@ -868,13 +867,11 @@ class Appliances:
 
 
 class WellbeingApiClient:
-    def __init__(self, hub: ElectroluxHubAPI, *, use_stream: bool) -> None:
+    def __init__(self, hub: ElectroluxHubAPI) -> None:
         """Sample API Client."""
         self._api_appliances: dict[str, ApiAppliance] = {}
         self._hub = hub
         self._load_lock = asyncio.Lock()
-        self._use_stream = use_stream
-        self._livestream_properties: dict[str, list[str]] = {}
 
     async def _ensure_loaded(self) -> None:
         if self._api_appliances:
@@ -884,22 +881,6 @@ class WellbeingApiClient:
                 return
             appliances: list[ApiAppliance] = await self._hub.async_get_appliances()
             self._api_appliances = {appliance.id: appliance for appliance in appliances}
-
-            if self._use_stream:
-                try:
-                    livestream_configs = (
-                        await self._hub.async_get_livestream_configurations()
-                    )
-                    for appliance_config in livestream_configs.get("appliances", []):
-                        appliance_id = appliance_config.get("applianceId")
-                        properties = appliance_config.get("properties", [])
-                        if appliance_id and properties:
-                            self._livestream_properties[appliance_id] = properties
-                            _LOGGER.debug(
-                                f"Appliance {appliance_id} supports livestreaming for properties: {properties}"
-                            )
-                except Exception as e:
-                    _LOGGER.warning(f"Failed to fetch livestream configurations: {e}")
 
     def update_appliance_state(self, ha_appliances, appliance_id, property_name, value):
         appliance = self._api_appliances.get(appliance_id)
@@ -936,30 +917,7 @@ class WellbeingApiClient:
         await self._ensure_loaded()
         found_appliances = {}
         for appliance in (appliance for appliance in self._api_appliances.values()):
-            livestream_props = self._livestream_properties.get(appliance.id, [])
-            # Only restore livestream properties if the appliance is actually connected to the livestream
-            # The connection state is updated by the live stream itself
-            is_streaming = appliance.state_data.get("connectionState") == "Connected"
-
-            if not livestream_props or not is_streaming:
-                await appliance.async_update()
-            else:
-                original_state = copy.deepcopy(appliance.state_data)
-                await appliance.async_update()
-
-                if (
-                    "properties" in appliance.state_data
-                    and "reported" in appliance.state_data["properties"]
-                ):
-                    for prop in livestream_props:
-                        if (
-                            "properties" in original_state
-                            and "reported" in original_state["properties"]
-                            and prop in original_state["properties"]["reported"]
-                        ):
-                            appliance.state_data["properties"]["reported"][prop] = (
-                                original_state["properties"]["reported"][prop]
-                            )
+            await appliance.async_update()
 
             model_name = appliance.type
             appliance_id = appliance.id

--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -872,6 +872,8 @@ class WellbeingApiClient:
         self._api_appliances: dict[str, ApiAppliance] = {}
         self._hub = hub
         self._load_lock = asyncio.Lock()
+        self._livestream_revision = 0
+        self._livestream_updates: dict[str, dict[str, tuple[int, object]]] = {}
 
     async def _ensure_loaded(self) -> None:
         if self._api_appliances:
@@ -887,14 +889,12 @@ class WellbeingApiClient:
         if appliance is None:
             return False
 
-        if property_name in ["status", "connectionState"]:
-            appliance.state_data[property_name] = value
-        else:
-            if "properties" not in appliance.state_data:
-                appliance.state_data["properties"] = {}
-            if "reported" not in appliance.state_data["properties"]:
-                appliance.state_data["properties"]["reported"] = {}
-            appliance.state_data["properties"]["reported"][property_name] = value
+        self._livestream_revision += 1
+        self._livestream_updates.setdefault(appliance_id, {})[property_name] = (
+            self._livestream_revision,
+            value,
+        )
+        self._set_appliance_state(appliance, property_name, value)
 
         _LOGGER.debug(
             f"Live stream update for {appliance_id}: {property_name} = {value}"
@@ -911,14 +911,39 @@ class WellbeingApiClient:
 
         return True
 
+    @staticmethod
+    def _set_appliance_state(appliance, property_name, value) -> None:
+        if property_name in ["status", "connectionState"]:
+            appliance.state_data[property_name] = value
+        else:
+            if "properties" not in appliance.state_data:
+                appliance.state_data["properties"] = {}
+            if "reported" not in appliance.state_data["properties"]:
+                appliance.state_data["properties"]["reported"] = {}
+            appliance.state_data["properties"]["reported"][property_name] = value
+
+    def _reapply_concurrent_livestream_updates(
+        self, appliance, poll_revision: int
+    ) -> None:
+        for property_name, (revision, value) in self._livestream_updates.get(
+            appliance.id, {}
+        ).items():
+            if revision > poll_revision:
+                self._set_appliance_state(appliance, property_name, value)
+
     async def async_get_appliances(self) -> Appliances:
         """Get data from the API."""
 
         await self._ensure_loaded()
+        for appliance in self._api_appliances.values():
+            poll_revision = self._livestream_revision
+            await appliance.async_update()
+            # The poll supersedes earlier stream values. Preserve only events
+            # received while this appliance request was in flight.
+            self._reapply_concurrent_livestream_updates(appliance, poll_revision)
+
         found_appliances = {}
         for appliance in (appliance for appliance in self._api_appliances.values()):
-            await appliance.async_update()
-
             model_name = appliance.type
             appliance_id = appliance.id
             appliance_name = appliance.name

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,7 +177,7 @@ async def test_api_client_ensure_loaded():
     mock_appliance.id = "pnc_1"
     mock_hub.async_get_appliances.return_value = [mock_appliance]
 
-    client = WellbeingApiClient(mock_hub, use_stream=False)
+    client = WellbeingApiClient(mock_hub)
     await client._ensure_loaded()
 
     assert "pnc_1" in client._api_appliances
@@ -186,19 +186,15 @@ async def test_api_client_ensure_loaded():
 
 @pytest.mark.asyncio
 async def test_api_client_livestream():
-    """Test livestream configuration fetching and state updates."""
+    """Test livestream state updates."""
     mock_hub = AsyncMock()
     mock_appliance = MagicMock()
     mock_appliance.id = "pnc_1"
     mock_appliance.state_data = {}
     mock_hub.async_get_appliances.return_value = [mock_appliance]
-    mock_hub.async_get_livestream_configurations.return_value = {
-        "appliances": [{"applianceId": "pnc_1", "properties": ["battery"]}]
-    }
-
-    client = WellbeingApiClient(mock_hub, use_stream=True)
+    client = WellbeingApiClient(mock_hub)
     await client._ensure_loaded()
-    assert client._livestream_properties["pnc_1"] == ["battery"]
+    mock_hub.async_get_livestream_configurations.assert_not_awaited()
 
     # Test update_appliance_state
     ha_appliances = MagicMock()
@@ -224,6 +220,6 @@ async def test_api_client_update_error():
         request_info=MagicMock(), history=(), status=401, message="Unauthorized"
     )
 
-    client = WellbeingApiClient(mock_hub, use_stream=False)
+    client = WellbeingApiClient(mock_hub)
     with pytest.raises(ClientResponseError):
         await client._ensure_loaded()

--- a/tests/test_livestream_polling.py
+++ b/tests/test_livestream_polling.py
@@ -1,0 +1,187 @@
+"""Tests for polling with livestream enabled."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.const import Platform
+
+from custom_components.wellbeing.api import WellbeingApiClient
+
+
+class FakeAppliance:
+    name = "Pure A9"
+    type = "PUREA9"
+    brand = "Electrolux"
+    serial_number = "serial-number"
+    device_type = "AIR_PURIFIER"
+    initial_data = {"applianceType": type}
+    capabilities_data = {"Fanspeed": {"access": "readwrite", "min": 1, "max": 9}}
+
+    def __init__(self, appliance_id="appliance-id"):
+        self.id = appliance_id
+        self.next_speed = 2
+        self.block_update = False
+        self.update_started = asyncio.Event()
+        self.continue_update = asyncio.Event()
+        self.state_data = {
+            "status": "enabled",
+            "connectionState": "Connected",
+            "properties": {"reported": {}},
+        }
+
+    @property
+    def state(self):
+        return self.state_data["properties"]["reported"]
+
+    async def async_update(self):
+        if self.block_update:
+            self.update_started.set()
+            await self.continue_update.wait()
+        self.state_data = {
+            "status": "enabled",
+            "connectionState": "Connected",
+            "properties": {
+                "reported": {
+                    "Workmode": "Manual",
+                    "Fanspeed": self.next_speed,
+                }
+            },
+        }
+
+
+@pytest.mark.asyncio
+async def test_polling_does_not_prefetch_livestream_configuration():
+    appliance = FakeAppliance()
+    hub = SimpleNamespace(
+        async_get_appliances=AsyncMock(return_value=[appliance]),
+        async_get_livestream_configurations=AsyncMock(),
+    )
+    client = WellbeingApiClient(hub)
+
+    await client.async_get_appliances()
+
+    hub.async_get_livestream_configurations.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_polling_replaces_intermediate_livestream_value():
+    appliance = FakeAppliance()
+    hub = SimpleNamespace(async_get_appliances=AsyncMock(return_value=[appliance]))
+    client = WellbeingApiClient(hub)
+
+    appliances = await client.async_get_appliances()
+    client.update_appliance_state(appliances, appliance.id, "Fanspeed", 8)
+    assert (
+        appliances.get_appliance(appliance.id)
+        .get_entity(Platform.FAN, "Fanspeed")
+        .state
+        == 8
+    )
+
+    appliance.next_speed = 3
+    appliances = await client.async_get_appliances()
+
+    assert (
+        appliances.get_appliance(appliance.id)
+        .get_entity(Platform.FAN, "Fanspeed")
+        .state
+        == 3
+    )
+
+
+@pytest.mark.asyncio
+async def test_livestream_update_during_poll_is_preserved():
+    appliance = FakeAppliance()
+    hub = SimpleNamespace(async_get_appliances=AsyncMock(return_value=[appliance]))
+    client = WellbeingApiClient(hub)
+    appliances = await client.async_get_appliances()
+
+    appliance.next_speed = 3
+    appliance.block_update = True
+    polling = asyncio.create_task(client.async_get_appliances())
+    await appliance.update_started.wait()
+
+    client.update_appliance_state(appliances, appliance.id, "Fanspeed", 8)
+    appliance.continue_update.set()
+    appliances = await polling
+
+    assert (
+        appliances.get_appliance(appliance.id)
+        .get_entity(Platform.FAN, "Fanspeed")
+        .state
+        == 8
+    )
+
+
+@pytest.mark.asyncio
+async def test_connection_event_during_poll_is_preserved():
+    appliance = FakeAppliance()
+    hub = SimpleNamespace(async_get_appliances=AsyncMock(return_value=[appliance]))
+    client = WellbeingApiClient(hub)
+    appliances = await client.async_get_appliances()
+
+    appliance.block_update = True
+    polling = asyncio.create_task(client.async_get_appliances())
+    await appliance.update_started.wait()
+
+    client.update_appliance_state(
+        appliances, appliance.id, "connectionState", "Disconnected"
+    )
+    appliance.continue_update.set()
+    appliances = await polling
+
+    assert (
+        appliances.get_appliance(appliance.id)
+        .get_entity(Platform.BINARY_SENSOR, "connectionState")
+        .state
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_for_polled_appliance_survives_other_appliance_poll():
+    first = FakeAppliance("first-id")
+    second = FakeAppliance("second-id")
+    hub = SimpleNamespace(async_get_appliances=AsyncMock(return_value=[first, second]))
+    client = WellbeingApiClient(hub)
+    appliances = await client.async_get_appliances()
+
+    first.next_speed = 3
+    second.block_update = True
+    polling = asyncio.create_task(client.async_get_appliances())
+    await second.update_started.wait()
+
+    client.update_appliance_state(appliances, first.id, "Fanspeed", 8)
+    second.continue_update.set()
+    appliances = await polling
+
+    assert (
+        appliances.get_appliance(first.id).get_entity(Platform.FAN, "Fanspeed").state
+        == 8
+    )
+
+
+@pytest.mark.asyncio
+async def test_poll_supersedes_event_received_before_appliance_request():
+    first = FakeAppliance("first-id")
+    second = FakeAppliance("second-id")
+    hub = SimpleNamespace(async_get_appliances=AsyncMock(return_value=[first, second]))
+    client = WellbeingApiClient(hub)
+    appliances = await client.async_get_appliances()
+
+    first.block_update = True
+    first.continue_update.clear()
+    second.next_speed = 3
+    polling = asyncio.create_task(client.async_get_appliances())
+    await first.update_started.wait()
+
+    client.update_appliance_state(appliances, second.id, "Fanspeed", 8)
+    first.continue_update.set()
+    appliances = await polling
+
+    assert (
+        appliances.get_appliance(second.id).get_entity(Platform.FAN, "Fanspeed").state
+        == 3
+    )


### PR DESCRIPTION
## Root cause

Polling treated an appliance's `connectionState: Connected` value as proof that this Home Assistant instance had an active livestream connection. It then restored every stream-capable property from a snapshot taken before the request, discarding newer values returned by the state endpoint and even events received while that request was in flight. If the stream was idle or disconnected, properties such as `Workmode` and `Fanspeed` could remain frozen indefinitely.

The integration also fetched the livestream configuration during appliance discovery even though [`watch_appliances()` owns configuration and reconnection](https://github.com/JohNan/pyelectroluxgroup/blob/v0.2.7/src/pyelectroluxgroup/api.py).

## Impact

Each appliance state request now supersedes stream values received before that request started. Livestream events received while a request is in progress are versioned and reapplied afterwards. Events received after an appliance was polled, including while another appliance is still updating, continue to update entities immediately.

Appliance discovery no longer duplicates the livestream configuration request. The stream listener, reconnect behavior, and reduced polling frequency introduced in #220 remain unchanged.

Regression tests cover stale pre-poll values, concurrent property and connection events, and ordering across multiple appliances.

Canary-tested on an Electrolux Pure A9: a forced coordinator refresh kept all 21 entities available, subsequent livestream sensor updates continued, and Home Assistant reported no new log problems.

Follow-up to #220 and #236.

Closes #221
