### PR TITLE
fix: handle modern API state shapes

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -200,15 +200,16 @@ class ApplianceBinary(ApplianceEntity):
 
     @property
     def state(self):
-        return self._state in [
-            "enabled",
-            True,
-            "Connected",
-            "on",
-            "ON",
-            "running",
-            "RUNNING",
-        ]
+        if isinstance(self._state, str):
+            return self._state.casefold() in {
+                "connected",
+                "enabled",
+                "on",
+                "running",
+                "true",
+                "yes",
+            }
+        return self._state is True or self._state == 1
 
 
 class ApplianceClimate(ApplianceEntity):
@@ -675,9 +676,10 @@ class Appliance:
         )
 
     def has_capability(self, capability) -> bool:
+        capability_data = self.capabilities.get(capability)
         return (
-            capability in self.capabilities
-            and self.capabilities[capability]["access"] == "readwrite"
+            isinstance(capability_data, dict)
+            and capability_data.get("access") == "readwrite"
         )
 
     def clear_mode(self):

--- a/custom_components/wellbeing/entity.py
+++ b/custom_components/wellbeing/entity.py
@@ -64,7 +64,7 @@ class WellbeingEntity(CoordinatorEntity):
             "capabilities": [
                 key
                 for key, value in self.get_appliance.capabilities.items()
-                if value["access"] == "readwrite"
+                if isinstance(value, dict) and value.get("access") == "readwrite"
             ],
         }
 


### PR DESCRIPTION
## Root cause

Binary state parsing matched a short case-sensitive list, while newer Electrolux payloads use lowercase values such as `connected` and enum-style values such as `YES` / `NO`. The payload reported in #159 therefore marked a connected dehumidifier as disconnected and could not represent a full water tank. Capability attributes also assumed every top-level entry had an `access` key, but the AC payload in #124 and the [official SDK fixtures](https://github.com/electrolux-oss/electrolux-group-developer-sdk/blob/v0.6.0/tests/client/appliances/data/appliance/ac_details.json) contain nested `networkInterface` objects without one.

## Impact

Known boolean states are normalized without changing existing boolean or numeric behavior. Lowercase connectivity and `YES` values now produce the expected binary state, while `disconnected`, `OFF`, and `NO` remain false. Nested capability groups are ignored when listing or checking writable features instead of raising `KeyError` during entity state updates.
