### PR TITLE
fix: align Cybele vacuum behavior

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -1139,22 +1139,29 @@ class WellbeingApiClient:
             if not api_map:
                 _LOGGER.error(f"No memory maps found for appliance with id {pnc_id}")
                 return
-            rooms_payload = [
-                {
-                    "roomId": segment_id,
-                    "sweepMode": 0,
-                    "vacuumMode": "standard",
-                    "waterPumpRate": "off",
-                    "numberOfCleaningRepetitions": 1,
+            if appliance.type == Model.Cybele.value:
+                command_payload = {
+                    "mapCommand": "selectRoomsClean",
+                    "mapId": api_map.id,
+                    "type": 0,
+                    "roomInfo": [{"roomId": segment_id} for segment_id in segment_ids],
                 }
-                for segment_id in segment_ids
-            ]
-            command_payload = {
-                "mapCommand": "selectRoomsClean",
-                "mapId": api_map.id,
-                "type": 1,
-                "roomInfo": rooms_payload,
-            }
+            else:
+                command_payload = {
+                    "mapCommand": "selectRoomsClean",
+                    "mapId": api_map.id,
+                    "type": 1,
+                    "roomInfo": [
+                        {
+                            "roomId": segment_id,
+                            "sweepMode": 0,
+                            "vacuumMode": "standard",
+                            "waterPumpRate": "off",
+                            "numberOfCleaningRepetitions": 1,
+                        }
+                        for segment_id in segment_ids
+                    ],
+                }
             result = await appliance.send_command(command_payload)
             _LOGGER.debug(
                 f"Sent clean segments command with data: {command_payload}, result: {result}"
@@ -1199,10 +1206,7 @@ class WellbeingApiClient:
             )
             return
 
-        if command == "clean_room" and appliance.type in [
-            Model.VacuumHygienic700.value,
-            Model.Cybele.value,
-        ]:
+        if command == "clean_room" and appliance.type == Model.VacuumHygienic700.value:
             if params is None:
                 raise ServiceValidationError(
                     f"Parameters are required for command '{command}'"
@@ -1254,7 +1258,7 @@ class WellbeingApiClient:
 
                 repetitions = room["repetitions"]
                 if not isinstance(repetitions, int):
-                    repetitions
+                    repetitions = 1
                     _LOGGER.debug(
                         f"Repetition 1 used as {room['room_name']} input is invalid."
                     )

--- a/custom_components/wellbeing/vacuum.py
+++ b/custom_components/wellbeing/vacuum.py
@@ -47,6 +47,9 @@ VACUUM_ACTIVITIES = {
     "goingHome": VacuumActivity.RETURNING,  # robot700series returning
     "paused": VacuumActivity.PAUSED,  # robot700series paused
     "sleeping": VacuumActivity.DOCKED,  # robot700series sleeping
+    "vacuuming": VacuumActivity.CLEANING,  # Cybele vacuuming
+    "mopping": VacuumActivity.CLEANING,  # Cybele mopping
+    "vaccumAndMopping": VacuumActivity.CLEANING,  # Cybele combined cleaning
 }
 
 


### PR DESCRIPTION
## Root cause

Cybele was initially added by sharing the 700-series / Gordias paths in #232. Its basic commands match those models, but its room-cleaning payload does not: the [official Electrolux SDK](https://github.com/electrolux-oss/electrolux-group-developer-sdk/blob/v0.6.0/electrolux_group_developer_sdk/client/appliances/rvc_appliance.py) uses `type: 0` with room IDs for global settings, while the integration sent the Gordias `type: 1` payload with `sweepMode`. Cybele also reports `vacuuming`, `mopping`, and the API-spelled `vaccumAndMopping` states, none of which were mapped to a Home Assistant activity. The documented Gordias `clean_room` fallback logged that it used one repetition for invalid input but did not actually replace the value.

## Impact

Home Assistant segment cleaning now sends the Cybele payload covered by the [official SDK tests](https://github.com/electrolux-oss/electrolux-group-developer-sdk/blob/v0.6.0/tests/client/appliances/test_rvc_appliance.py), and active Cybele cleaning modes report `cleaning` instead of `error`. The Gordias segment payload is unchanged, invalid repetition input really falls back to `1`, and its model-specific custom command is no longer offered to Cybele with an incompatible payload.

Follow-up to #231 and #232
