### PR TITLE
fix: skip unsupported appliance models

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -963,7 +963,16 @@ class WellbeingApiClient:
             ):
                 continue
 
-            app = Appliance(appliance_name, appliance_id, model_name)
+            try:
+                app = Appliance(appliance_name, appliance_id, model_name)
+            except ValueError:
+                _LOGGER.warning(
+                    "Skipping unsupported %s appliance %s with model %s",
+                    appliance.device_type,
+                    appliance_id,
+                    model_name,
+                )
+                continue
             app.brand = appliance.brand
             app.serialNumber = appliance.serial_number
             app.device = appliance.device_type


### PR DESCRIPTION
## Root cause

The integration converts every supported device category into a closed `Model` enum. Electrolux can return appliance types that this integration has not implemented yet (for example `Fuji` or `DH`), so constructing one such appliance raises `ValueError` and aborts the complete coordinator refresh.

The [official Electrolux SDK factory](https://github.com/electrolux-oss/electrolux-group-developer-sdk/blob/main/electrolux_group_developer_sdk/client/appliance_data_factory.py) also treats unrecognized appliance types as a normal compatibility case by falling back to its base appliance class.

## Impact

An unimplemented model is now skipped with a warning containing its device category, appliance ID, and model. Other supported appliances continue loading normally.

This deliberately does not claim support for the skipped model: appliance families such as Fuji and DH use different state and command schemas and need dedicated implementations.

Related to #174, #202, and #222.
