### PR TITLE
fix: create vacuum camera before map data

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -224,6 +224,10 @@ class ApplianceCamera(ApplianceEntity):
     def __init__(self, name, attr) -> None:
         super().__init__(name, attr)
 
+    def setup(self, data):
+        self._state = data.get(self.source_attr, {})
+        return self
+
 
 class ApplianceConsumableSensor(ApplianceSensor):
     """Remaining life of a consumable, in percent.
@@ -715,6 +719,10 @@ class Appliance:
             entity.setup(data)
             for entity in Appliance._create_entities(data)
             if entity.source_attr in data
+            or (
+                isinstance(entity, ApplianceCamera)
+                and self.device == "ROBOTIC_VACUUM_CLEANER"
+            )
         ]
 
     @property


### PR DESCRIPTION
## Root cause

The map camera added in #233 is included only when `mapData` is present during the initial coordinator refresh. Home Assistant registers platform entities during setup, so a PUREi9 whose first state does not yet contain map data never gets a camera entity even if later refreshes contain it.

The [Home Assistant camera entity contract](https://developers.home-assistant.io/docs/core/entity/camera/) permits `async_camera_image` to return `None` while an image is not available.

## Impact

Known robotic vacuum cleaners now register the map camera during setup. It starts with no image and uses the existing renderer as soon as `mapData` arrives. Air purifiers and other appliance categories do not gain a camera entity.

Closes #241.
