### PR TITLE
fix: normalize air conditioner modes

### DIFF
--- a/custom_components/wellbeing/climate.py
+++ b/custom_components/wellbeing/climate.py
@@ -87,7 +87,10 @@ class WellbeingClimate(WellbeingEntity, ClimateEntity):
             is False
         ):
             return HVACMode.OFF
-        return HVAC_MODES.get(self.get_entity.state, HVACMode.AUTO)
+        mode = self.get_entity.state
+        return HVAC_MODES.get(
+            mode.lower() if isinstance(mode, str) else mode, HVACMode.AUTO
+        )
 
     @property
     def hvac_action(self) -> HVACAction | None:


### PR DESCRIPTION
## Root cause

The climate entity looks up the reported `mode` with case-sensitive lowercase keys. The payload attached to #124 uses lowercase values, while the [official Electrolux SDK fixture](https://github.com/electrolux-oss/electrolux-group-developer-sdk/blob/v0.6.0/tests/client/appliances/data/appliance/ac_state.json) uses uppercase enum values. An active `COOL`, `DRY`, or `FANONLY` state therefore falls back to the default HVAC mode.

## Impact

Air conditioner modes are normalized before mapping them to the corresponding [Home Assistant HVAC mode](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes). Existing lowercase payloads remain unchanged, and uppercase payloads now report the actual operation instead of the fallback.

Follow-up to #124 and #211
