### PR TITLE
Adds translations to vacuum fan speeds

### DIFF
--- a/custom_components/wellbeing/translations/de.json
+++ b/custom_components/wellbeing/translations/de.json
@@ -31,5 +31,22 @@
         }
       }
     }
+  },
+  "entity": {
+    "vacuum": {
+      "vacuum": {
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "quiet": "Leise",
+              "smart": "Smart",
+              "power": "Power",
+              "eco": "Eco",
+              "standard": "Standard"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/wellbeing/translations/en.json
+++ b/custom_components/wellbeing/translations/en.json
@@ -42,5 +42,22 @@
         }
       }
     }
+  },
+  "entity": {
+    "vacuum": {
+      "vacuum": {
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "quiet": "Quiet",
+              "smart": "Smart",
+              "power": "Power",
+              "eco": "Eco",
+              "standard": "Standard"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/wellbeing/translations/fr.json
+++ b/custom_components/wellbeing/translations/fr.json
@@ -33,5 +33,22 @@
         }
       }
     }
+  },
+  "entity": {
+    "vacuum": {
+      "vacuum": {
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "quiet": "Silencieux",
+              "smart": "Smart",
+              "power": "Power",
+              "eco": "Eco",
+              "standard": "Standard"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/wellbeing/translations/nb.json
+++ b/custom_components/wellbeing/translations/nb.json
@@ -33,5 +33,22 @@
         }
       }
     }
+  },
+  "entity": {
+    "vacuum": {
+      "vacuum": {
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "quiet": "Stille",
+              "smart": "Smart",
+              "power": "Power",
+              "eco": "Eco",
+              "standard": "Standard"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/wellbeing/translations/nl.json
+++ b/custom_components/wellbeing/translations/nl.json
@@ -39,5 +39,22 @@
         }
       }
     }
+  },
+  "entity": {
+    "vacuum": {
+      "vacuum": {
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "quiet": "Stil",
+              "smart": "Smart",
+              "power": "Power",
+              "eco": "Eco",
+              "standard": "Standaard"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/wellbeing/translations/pl.json
+++ b/custom_components/wellbeing/translations/pl.json
@@ -39,5 +39,22 @@
         }
       }
     }
+  },
+  "entity": {
+    "vacuum": {
+      "vacuum": {
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "quiet": "Cichy",
+              "smart": "Smart",
+              "power": "Power",
+              "eco": "Eco",
+              "standard": "Standardowy"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/wellbeing/translations/sv.json
+++ b/custom_components/wellbeing/translations/sv.json
@@ -39,5 +39,22 @@
         }
       }
     }
+  },
+  "entity": {
+    "vacuum": {
+      "vacuum": {
+        "state_attributes": {
+          "fan_speed": {
+            "state": {
+              "quiet": "Tyst",
+              "smart": "Smart",
+              "power": "Power",
+              "eco": "Eco",
+              "standard": "Standard"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/wellbeing/vacuum.py
+++ b/custom_components/wellbeing/vacuum.py
@@ -74,6 +74,8 @@ async def async_setup_entry(hass, entry, async_add_devices):
 class WellbeingVacuum(WellbeingEntity, StateVacuumEntity):
     """wellbeing Sensor class."""
 
+    _attr_translation_key = "vacuum"
+
     def __init__(
         self,
         coordinator: WellbeingDataUpdateCoordinator,


### PR DESCRIPTION
Adds translations to vacuum fan speed strings to make the text look nicer (and translated for non-English users) in the GUI.

**Note:** The Swedish translation file was called se.json, not sv.json as it should be according to the [Supported languages](https://developers.home-assistant.io/docs/voice/intent-recognition/supported-languages/) documentation, so the file name was changed as part of the PR.

**Testing:** Tested in English and Swedish on HA. English and Swedish strings are confirmed to be identical to those in the Electrolux app for the Purei9.2. All other strings are best (Claude Code) guesses that can be used as placeholders for users of other vacuums and languages to update.