### PR TITLE
Fixes a deprecated units (constant) warning as of 2026.9

### DIFF
--- a/custom_components/wellbeing/api.py
+++ b/custom_components/wellbeing/api.py
@@ -10,13 +10,12 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.vacuum import Segment
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_BILLION,
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     EntityCategory,
     Platform,
     UnitOfArea,
+    UnitOfDensity,
+    UnitOfRatio,
     UnitOfTemperature,
     UnitOfTime,
 )
@@ -304,7 +303,7 @@ class Appliance:
             ApplianceSensor(
                 name="PM2.5",
                 attr="pm25",
-                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
                 device_class=SensorDeviceClass.PM25,
                 state_class=SensorStateClass.MEASUREMENT,
             ),
@@ -379,7 +378,7 @@ class Appliance:
             ApplianceSensor(
                 name="PM2.5",
                 attr="PM2_5_approximate",
-                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
                 device_class=SensorDeviceClass.PM25,
                 state_class=SensorStateClass.MEASUREMENT,
             ),
@@ -441,7 +440,7 @@ class Appliance:
             ApplianceSensor(
                 name="CO2",
                 attr="CO2",
-                unit=CONCENTRATION_PARTS_PER_MILLION,
+                unit=UnitOfRatio.PARTS_PER_MILLION,
                 device_class=SensorDeviceClass.CO2,
                 state_class=SensorStateClass.MEASUREMENT,
             ),
@@ -566,34 +565,34 @@ class Appliance:
             ApplianceSensor(
                 name="TVOC",
                 attr="TVOC",
-                unit=CONCENTRATION_PARTS_PER_BILLION,
+                unit=UnitOfRatio.PARTS_PER_BILLION,
                 state_class=SensorStateClass.MEASUREMENT,
             ),
             ApplianceSensor(
                 name="eCO2",
                 attr="ECO2",
-                unit=CONCENTRATION_PARTS_PER_MILLION,
+                unit=UnitOfRatio.PARTS_PER_MILLION,
                 device_class=SensorDeviceClass.CO2,
                 state_class=SensorStateClass.MEASUREMENT,
             ),
             ApplianceSensor(
                 name="PM1",
                 attr="PM1",
-                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
                 device_class=SensorDeviceClass.PM1,
                 state_class=SensorStateClass.MEASUREMENT,
             ),
             ApplianceSensor(
                 name="PM2.5",
                 attr="PM2_5",
-                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
                 device_class=SensorDeviceClass.PM25,
                 state_class=SensorStateClass.MEASUREMENT,
             ),
             ApplianceSensor(
                 name="PM10",
                 attr="PM10",
-                unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                unit=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
                 device_class=SensorDeviceClass.PM10,
                 state_class=SensorStateClass.MEASUREMENT,
             ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp
-homeassistant==2026.6.0
+homeassistant==2026.9.0
 pyelectroluxgroup==0.2.7


### PR DESCRIPTION
Fixes a deprecated constant warning that appears as of 2026.9.

**Log example:**

Logger: homeassistant.const
Source: helpers/deprecation.py:272
First occurred: 08:39:06 (3 occurrences)
Last logged: 08:39:06

The deprecated constant CONCENTRATION_MICROGRAMS_PER_CUBIC_METER was used from wellbeing. It will be removed in HA Core 2027.8. Use UnitOfDensity.MICROGRAMS_PER_CUBIC_METER instead, please report it to the author of the 'wellbeing' custom integration
The deprecated constant CONCENTRATION_PARTS_PER_BILLION was used from wellbeing. It will be removed in HA Core 2027.8. Use UnitOfRatio.PARTS_PER_BILLION instead, please report it to the author of the 'wellbeing' custom integration
The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from wellbeing. It will be removed in HA Core 2027.8. Use UnitOfRatio.PARTS_PER_MILLION instead, please report it to the author of the 'wellbeing' custom integration

